### PR TITLE
Downloading software should always be over TLS

### DIFF
--- a/README
+++ b/README
@@ -76,7 +76,7 @@ See html/index.html for more details about ExifTool features.
 
 ExifTool can be downloaded from
 
-  http://owl.phy.queensu.ca/~phil/exiftool/
+  https://owl.phy.queensu.ca/~phil/exiftool/
 
 RUNNING
 


### PR DESCRIPTION
It seems like the host supports TLS and has HTTPS. Changing the URL to HTTPS makes sure of the data integrity during the download... it also leaves less metadata and in fewer places ;)