### PR TITLE
Only calculate gps value if all rational are valid

### DIFF
--- a/lib/Image/ExifTool/GPS.pm
+++ b/lib/Image/ExifTool/GPS.pm
@@ -535,6 +535,7 @@ sub ToDegrees($;$)
 {
     my ($val, $doSign) = @_;
     # extract decimal or floating point values out of any other garbage
+    return '' if ($val =~ /(inf|undef)/);
     my ($d, $m, $s) = ($val =~ /((?:[+-]?)(?=\d|\.\d)\d*(?:\.\d*)?(?:[Ee][+-]\d+)?)/g);
     return '' unless defined $d;
     my $deg = $d + (($m || 0) + ($s || 0)/60) / 60;


### PR DESCRIPTION
I found that exiftool will try to convert GPS coordinates no matter what. If the `rational64[3]` is partially broken e.g you have something like `1/0 6/0 36/1` as a fraction the value will be converted to `36 degrees` due to the regex will match at least the last portion.
This fix would skip convertion if any of the fraction is invalid.