### PR TITLE
Allow filenames to be objects (Path::Tiny and similar)

### DIFF
--- a/lib/Image/ExifTool.pm
+++ b/lib/Image/ExifTool.pm
@@ -19,6 +19,7 @@ use strict;
 require 5.004;  # require 5.004 for UNIVERSAL::isa (otherwise 5.002 would do)
 require Exporter;
 use File::RandomAccess;
+use overload ();
 
 use vars qw($VERSION $RELEASE @ISA @EXPORT_OK %EXPORT_TAGS $AUTOLOAD @fileTypes
             %allTables @tableOrder $exifAPP1hdr $xmpAPP1hdr $xmpExtAPP1hdr
@@ -4046,7 +4047,7 @@ sub ParseArguments($;@)
     # handle our input arguments
     while (@_) {
         my $arg = shift;
-        if (ref $arg) {
+        if (ref $arg && !overload::Method($arg, q[""])) {
             if (ref $arg eq 'ARRAY') {
                 $$self{IO_TAG_LIST} = $arg;
                 foreach (@$arg) {

--- a/t/ExifTool.t
+++ b/t/ExifTool.t
@@ -2,7 +2,7 @@
 # After "make install" it should work as "perl t/ExifTool.t".
 
 BEGIN {
-    $| = 1; print "1..31\n"; $Image::ExifTool::configFile = '';
+    $| = 1; print "1..32\n"; $Image::ExifTool::configFile = '';
     require './t/TestLib.pm'; t::TestLib->import();
 }
 END {print "not ok 1\n" unless $loaded;}
@@ -339,6 +339,22 @@ my $testnum = 1;
     ++$testnum;
     my $exifTool = new Image::ExifTool;
     my $info = $exifTool->ImageInfo('t/images/CanonRaw.cr2', 'Validate', 'Warning', 'Error');
+    print 'not ' unless check($exifTool, $info, $testname, $testnum);
+    print "ok $testnum\n";
+}
+
+# test 32: Filename can be an object (such as from Path::Class or Path::Tiny)
+{
+
+    {
+      package FileObj;
+      use overload fallback => 1, q[""] => sub { shift->{name} };
+    }
+    # Same as test 2 above:
+    my $file = bless {name => 't/images/ExifTool.jpg'}, 'FileObj';
+    ++$testnum;
+    my $exifTool = new Image::ExifTool;
+    my $info = $exifTool->ImageInfo($file);
     print 'not ' unless check($exifTool, $info, $testname, $testnum);
     print "ok $testnum\n";
 }

--- a/t/ExifTool_32.out
+++ b/t/ExifTool_32.out
@@ -1,0 +1,427 @@
+[ExifTool, ExifTool, ExifTool] ExifToolVersion - ExifTool Version Number: 11.78
+[File, System, Other] FileName - File Name: ExifTool.jpg
+[File, System, Other] Directory - Directory: t/images
+[File, System, Other] FileSize - File Size: 25 kB
+[File, System, Time] FileModifyDate - File Modification Date/Time: 2019:12:04 10:56:48-05:00
+[File, System, Time] FileAccessDate - File Access Date/Time: 2019:12:04 11:01:15-05:00
+[File, System, Time] FileInodeChangeDate - File Inode Change Date/Time: 2019:12:04 10:56:48-05:00
+[File, System, Other] FilePermissions - File Permissions: rw-r--r--
+[File, File, Other] FileType - File Type: JPEG
+[File, File, Other] FileTypeExtension - File Type Extension: jpg
+[File, File, Other] MIMEType - MIME Type: image/jpeg
+[File, File, Image] ExifByteOrder - Exif Byte Order: Little-endian (Intel, II)
+[File, File, Image] Comment - Comment: © PhotoStudio Unicode comment;;
+[File, File, Image] CurrentIPTCDigest - Current IPTC Digest: 6895be53ef9a287520f400aa17242c09
+[File, File, Image] Comment - Comment: a comment
+[File, File, Image] ImageWidth - Image Width: 8
+[File, File, Image] ImageHeight - Image Height: 8
+[File, File, Image] EncodingProcess - Encoding Process: Baseline DCT, Huffman coding
+[File, File, Image] BitsPerSample - Bits Per Sample: 8
+[File, File, Image] ColorComponents - Color Components: 3
+[File, File, Image] YCbCrSubSampling - Y Cb Cr Sub Sampling: YCbCr4:2:0 (2 2)
+[EXIF, IFD0, Image] 270 - Image Description: A witty caption
+[EXIF, IFD0, Camera] 271 - Make: FUJIFILM
+[EXIF, IFD0, Camera] 272 - Camera Model Name: FinePix2400Zoom
+[EXIF, IFD0, Image] 274 - Orientation: Horizontal (normal)
+[EXIF, IFD0, Image] 282 - X Resolution: 72
+[EXIF, IFD0, Image] 283 - Y Resolution: 72
+[EXIF, IFD0, Image] 296 - Resolution Unit: inches
+[EXIF, IFD0, Image] 305 - Software: Adobe Photoshop 7.0
+[EXIF, IFD0, Time] 306 - Modify Date: 2004:02:26 09:36:46
+[EXIF, IFD0, Author] 315 - Artist: Phil Harvey
+[EXIF, IFD0, Image] 531 - Y Cb Cr Positioning: Co-sited
+[EXIF, IFD0, Author] 33432 - Copyright: Copyright 2004 Phil Harvey
+[EXIF, ExifIFD, Image] 33437 - F Number: 3.5
+[EXIF, ExifIFD, Camera] 34850 - Exposure Program: Program AE
+[EXIF, ExifIFD, Image] 34855 - ISO: 100
+[EXIF, ExifIFD, Image] 36864 - Exif Version: 0210
+[EXIF, ExifIFD, Time] 36867 - Date/Time Original: 2001:05:19 18:36:41
+[EXIF, ExifIFD, Time] 36868 - Create Date: 2001:05:19 18:36:41
+[EXIF, ExifIFD, Image] 37121 - Components Configuration: Y, Cb, Cr, -
+[EXIF, ExifIFD, Image] 37122 - Compressed Bits Per Pixel: 1.6
+[EXIF, ExifIFD, Image] 37377 - Shutter Speed Value: 1/64
+[EXIF, ExifIFD, Image] 37378 - Aperture Value: 3.5
+[EXIF, ExifIFD, Image] 37379 - Brightness Value: 2
+[EXIF, ExifIFD, Image] 37380 - Exposure Compensation: 0
+[EXIF, ExifIFD, Camera] 37381 - Max Aperture Value: 3.5
+[EXIF, ExifIFD, Camera] 37383 - Metering Mode: Multi-segment
+[EXIF, ExifIFD, Camera] 37385 - Flash: Fired
+[EXIF, ExifIFD, Camera] 37386 - Focal Length: 6.0 mm
+[EXIF, ExifIFD, Image] 40960 - Flashpix Version: 0100
+[EXIF, ExifIFD, Image] 40961 - Color Space: sRGB
+[EXIF, ExifIFD, Image] 40962 - Exif Image Width: 100
+[EXIF, ExifIFD, Image] 40963 - Exif Image Height: 80
+[EXIF, ExifIFD, Camera] 41486 - Focal Plane X Resolution: 3053
+[EXIF, ExifIFD, Camera] 41487 - Focal Plane Y Resolution: 3053
+[EXIF, ExifIFD, Camera] 41488 - Focal Plane Resolution Unit: cm
+[EXIF, ExifIFD, Camera] 41495 - Sensing Method: One-chip color area
+[EXIF, ExifIFD, Image] 41728 - File Source: Digital Camera
+[EXIF, ExifIFD, Image] 41729 - Scene Type: Directly photographed
+[EXIF, IFD1, Image] 259 - Compression: JPEG (old-style)
+[EXIF, IFD1, Image] 282 - X Resolution: 72
+[EXIF, IFD1, Image] 283 - Y Resolution: 72
+[EXIF, IFD1, Image] 296 - Resolution Unit: inches
+[EXIF, IFD1, Image] 513 - Thumbnail Offset: 852
+[EXIF, IFD1, Image] 514 - Thumbnail Length: 0
+[JFIF, JFIF, Image] 0 - JFIF Version: 1.01
+[JFIF, JFIF, Image] 2 - Resolution Unit: inches
+[JFIF, JFIF, Image] 3 - X Resolution: 144
+[JFIF, JFIF, Image] 5 - Y Resolution: 144
+[JFIF, JFXX, Preview] 16 - Thumbnail Image: (Binary data 1558 bytes)
+[APP8, SPIFF, Image] 0 - SPIFF Version: 1.2
+[APP8, SPIFF, Image] 2 - Profile ID: Continuous-tone Base
+[APP8, SPIFF, Image] 3 - Color Components: 3
+[APP8, SPIFF, Image] 6 - Image Height: 4500
+[APP8, SPIFF, Image] 10 - Image Width: 3000
+[APP8, SPIFF, Image] 14 - Color Space: YCbCr, ITU-R BT 709, video
+[APP8, SPIFF, Image] 15 - Bits Per Sample: 8
+[APP8, SPIFF, Image] 16 - Compression: JPEG
+[APP8, SPIFF, Image] 17 - Resolution Unit: inches
+[APP8, SPIFF, Image] 18 - Y Resolution: 300
+[APP8, SPIFF, Image] 22 - X Resolution: 300
+[MakerNotes, CIFF, Image] 0 - File Format: JPEG (lossy)
+[MakerNotes, CIFF, Image] 1 - Target Compression Ratio: 2
+[MakerNotes, CIFF, Image] 0 - Image Width: 512
+[MakerNotes, CIFF, Image] 1 - Image Height: 384
+[MakerNotes, CIFF, Image] 2 - Pixel Aspect Ratio: 1
+[MakerNotes, CIFF, Image] 3 - Rotation: 0
+[MakerNotes, CIFF, Image] 4 - Component Bit Depth: 8
+[MakerNotes, CIFF, Image] 5 - Color Bit Depth: 24
+[MakerNotes, CIFF, Image] 6 - Color BW: 1
+[MakerNotes, CIFF, Camera] 4106 - Target Image Type: Real-world Subject
+[MakerNotes, CIFF, Camera] 6148 - Record ID: 0
+[MakerNotes, CIFF, Image] 6167 - File Number: 45
+[MakerNotes, CIFF, Time] 0 - Date/Time Original: 1998:05:01 21:33:18
+[MakerNotes, CIFF, Time] 1 - Time Zone Code: 0
+[MakerNotes, CIFF, Time] 2 - Time Zone Info: 0
+[MakerNotes, CIFF, Camera] 2070 - Original File Name: C:\DC97\CTG_0000\AUT_0045.JPG
+[MakerNotes, CIFF, Camera] 2071 - Thumbnail File Name: C:\DC97\CTG_0000\THM_0045.JPG
+[MakerNotes, CIFF, Camera] 4112 - Shutter Release Method: Single Shot
+[MakerNotes, CIFF, Camera] 4113 - Shutter Release Timing: Priority on focus
+[MakerNotes, CIFF, Image] 0 - Flash Guide Number: 0
+[MakerNotes, CIFF, Image] 1 - Flash Threshold: 0
+[MakerNotes, CIFF, Image] 0 - Exposure Compensation: 1
+[MakerNotes, CIFF, Image] 1 - Shutter Speed Value: 1/83
+[MakerNotes, CIFF, Image] 2 - Aperture Value: 6.2
+[MakerNotes, CIFF, Camera] 6151 - Target Distance Setting: 476 mm
+[MakerNotes, CIFF, Camera] 6164 - Measured EV: 16.25
+[MakerNotes, CIFF, Camera] 2053 - Canon File Description: 
+[MakerNotes, CIFF, Camera] 2069 - Canon Image Type: AUT:Full automatic mode
+[MakerNotes, CIFF, Camera] 2064 - Owner Name: 
+[MakerNotes, CIFF, Camera] 0 - Make: Canon
+[MakerNotes, CIFF, Camera] 6 - Camera Model Name: Canon PowerShot A5
+[MakerNotes, CIFF, Camera] 4124 - Base ISO: 100
+[MakerNotes, CIFF, Camera] 2061 - ROM Operation Mode: USA
+[MakerNotes, CIFF, Camera] 2059 - Canon Firmware Version: Firmware Version 01.00
+[MakerNotes, CIFF, Camera] 1 - Free Bytes: (Binary data 12 bytes)
+[MakerNotes, CIFF, Image] 0 - Focal Type: Fixed
+[MakerNotes, CIFF, Image] 1 - Focal Length: 5 mm
+[MakerNotes, CIFF, Image] 2 - Focal Plane X Size: 5.05 mm
+[MakerNotes, CIFF, Image] 3 - Focal Plane Y Size: 3.71 mm
+[MakerNotes, Qualcomm, Camera] aec_current_sensor_luma - AEC Current Sensor Luma: 22
+[MakerNotes, Qualcomm, Camera] af_position - AF Position: 26
+[MakerNotes, Qualcomm, Camera] aec_current_exp_index - AEC Current Exp Index: 308
+[MakerNotes, Qualcomm, Camera] awb_sample_decision - AWB Sample Decision: 7
+[MakerNotes, Qualcomm, Camera] asf5_enable - ASF5 Enable: 1
+[MakerNotes, Qualcomm, Camera] asf5_filter_mode - ASF5 Filter Mode: 0
+[MakerNotes, Qualcomm, Camera] asf5_exposure_index_1 - ASF5 Exposure Index 1: 180
+[MakerNotes, Qualcomm, Camera] asf5_exposure_index_2 - ASF5 Exposure Index 2: 270
+[MakerNotes, Qualcomm, Camera] asf5_max_exposure_index - ASF5 Max Exposure Index: 290
+[MakerNotes, Samsung, Other] 0x0100-name - Embedded Audio File Name: SoundShot_000
+[MakerNotes, Samsung, Audio] 0x0100 - Embedded Audio File: (Binary data 16 bytes)
+[APP0, AVI1, Image] 0 - Interleaved Field: Not Interleaved
+[XMP, XMP-x, Document] xmptk - XMP Toolkit: Image::ExifTool 4.73
+[XMP, XMP-rdf, Document] about - About: uuid:80056b68-1045-fa97-3401-6f4ed84cd53d
+[XMP, XMP-dc, Author] creator - Creator: Phil Harvey
+[XMP, XMP-dc, Image] description - Description: UTF-16 (big-endian) encoded XMP
+[XMP, XMP-dc, Author] rights - Rights: Copyright 2004 Phil Harvey
+[XMP, XMP-dc, Image] subject - Subject: ExifTool, Test, XMP
+[XMP, XMP-dc, Image] title - Title: Test IPTC picture
+[XMP, XMP-photoshop, Author] AuthorsPosition - Authors Position: My Position
+[XMP, XMP-photoshop, Author] CaptionWriter - Caption Writer: I wrote it
+[XMP, XMP-photoshop, Image] Category - Category: 1
+[XMP, XMP-photoshop, Location] City - City: Kingston
+[XMP, XMP-photoshop, Location] Country - Country: Canada
+[XMP, XMP-photoshop, Author] Credit - Credit: My Credit
+[XMP, XMP-photoshop, Time] DateCreated - Date Created: 2004:02:26
+[XMP, XMP-photoshop, Image] Headline - Headline: No headline
+[XMP, XMP-photoshop, Image] Instructions - Instructions: What instructions
+[XMP, XMP-photoshop, Author] Source - Source: I'm the source
+[XMP, XMP-photoshop, Location] State - State: Ont
+[XMP, XMP-photoshop, Image] SupplementalCategories - Supplemental Categories: amazing, image, utilities
+[XMP, XMP-photoshop, Image] TransmissionReference - Transmission Reference: What is a transmission reference?
+[XMP, XMP-photoshop, Image] Urgency - Urgency: 8 (least urgent)
+[XMP, XMP-xmpBJ, Other] JobRefName - Job Ref Name: My Job
+[XMP, XMP-xmpMM, Other] DocumentID - Document ID: adobe:docid:photoshop:4cc7b857-69d0-11d8-8ac4-bb59c92f0d9a
+[XMP, XMP-xmpRights, Author] Marked - Marked: False
+[XMP, XMP-xmpRights, Author] WebStatement - Web Statement: https://exiftool.org/
+[ICC_Profile, ICC-header, Image] 4 - Profile CMM Type: Adobe Systems Inc.
+[ICC_Profile, ICC-header, Image] 8 - Profile Version: 2.1.0
+[ICC_Profile, ICC-header, Image] 12 - Profile Class: Display Device Profile
+[ICC_Profile, ICC-header, Image] 16 - Color Space Data: RGB 
+[ICC_Profile, ICC-header, Image] 20 - Profile Connection Space: XYZ 
+[ICC_Profile, ICC-header, Time] 24 - Profile Date Time: 1999:06:03 00:00:00
+[ICC_Profile, ICC-header, Image] 36 - Profile File Signature: acsp
+[ICC_Profile, ICC-header, Image] 40 - Primary Platform: Apple Computer Inc.
+[ICC_Profile, ICC-header, Image] 44 - CMM Flags: Not Embedded, Independent
+[ICC_Profile, ICC-header, Image] 48 - Device Manufacturer: none
+[ICC_Profile, ICC-header, Image] 52 - Device Model: 
+[ICC_Profile, ICC-header, Image] 56 - Device Attributes: Reflective, Glossy, Positive, Color
+[ICC_Profile, ICC-header, Image] 64 - Rendering Intent: Perceptual
+[ICC_Profile, ICC-header, Image] 68 - Connection Space Illuminant: 0.9642 1 0.82491
+[ICC_Profile, ICC-header, Image] 80 - Profile Creator: Adobe Systems Inc.
+[ICC_Profile, ICC-header, Image] 84 - Profile ID: 0
+[ICC_Profile, ICC_Profile, Image] cprt - Profile Copyright: Copyright 1999 Adobe Systems Incorporated
+[ICC_Profile, ICC_Profile, Image] desc - Profile Description: Adobe RGB (1998)
+[ICC_Profile, ICC_Profile, Image] wtpt - Media White Point: 0.95045 1 1.08905
+[ICC_Profile, ICC_Profile, Image] bkpt - Media Black Point: 0 0 0
+[ICC_Profile, ICC_Profile, Image] rTRC - Red Tone Reproduction Curve: (Binary data 14 bytes)
+[ICC_Profile, ICC_Profile, Image] gTRC - Green Tone Reproduction Curve: (Binary data 14 bytes)
+[ICC_Profile, ICC_Profile, Image] bTRC - Blue Tone Reproduction Curve: (Binary data 14 bytes)
+[ICC_Profile, ICC_Profile, Image] rXYZ - Red Matrix Column: 0.60974 0.31111 0.01947
+[ICC_Profile, ICC_Profile, Image] gXYZ - Green Matrix Column: 0.20528 0.62567 0.06087
+[ICC_Profile, ICC_Profile, Image] bXYZ - Blue Matrix Column: 0.14919 0.06322 0.74457
+[FlashPix, FlashPix, Other] 1 - Code Page: Unicode UTF-16, little endian
+[FlashPix, FlashPix, Other] 268435456 - Used Extension Numbers: 1
+[FlashPix, FlashPix, Other] 1 - Extension Name: Screen nail
+[FlashPix, FlashPix, Other] 2 - Extension Class ID: 10000230-6FC0-11D0-BD01-00609719A180
+[FlashPix, FlashPix, Other] 3 - Extension Persistence: Invalidated By Modification
+[FlashPix, FlashPix, Time] 4 - Extension Create Date: 1999:05:14 21:47:25
+[FlashPix, FlashPix, Time] 5 - Extension Modify Date: 1999:05:14 21:47:25
+[FlashPix, FlashPix, Other] 6 - Creating Application: Digita
+[FlashPix, FlashPix, Other] 7 - Extension Description: Presized image for LCD display
+[FlashPix, FlashPix, Other] 4096 - Storage-Stream Pathname: /.Screen Nail_bd0100609719a180
+[FlashPix, FlashPix, Other] Screen Nail - Screen Nail: (Binary data 5917 bytes)
+[FlashPix, FlashPix, Preview] FlashPix::PreviewImage - Preview Image: (Binary data 5777 bytes)
+[MPF, MPF0, Image] 45056 - MPF Version: 0100
+[MPF, MPF0, Image] 45057 - Number Of Images: 2
+[MPF, MPImage1, Image] 0.1 - MP Image Flags: Dependent parent image
+[MPF, MPImage1, Image] 0.2 - MP Image Format: JPEG
+[MPF, MPImage1, Image] 0.3 - MP Image Type: Baseline MP Primary Image
+[MPF, MPImage1, Image] 4 - MP Image Length: 5959981
+[MPF, MPImage1, Image] 8 - MP Image Start: 0
+[MPF, MPImage1, Image] 12 - Dependent Image 1 Entry Number: 2
+[MPF, MPImage1, Image] 14 - Dependent Image 2 Entry Number: 0
+[MPF, MPImage2, Image] 0.1 - MP Image Flags: Dependent child image
+[MPF, MPImage2, Image] 0.2 - MP Image Format: JPEG
+[MPF, MPImage2, Image] 0.3 - MP Image Type: Large Thumbnail (full HD equivalent)
+[MPF, MPImage2, Image] 4 - MP Image Length: 1039273
+[MPF, MPImage2, Image] 8 - MP Image Start: 5945405
+[MPF, MPImage2, Image] 12 - Dependent Image 1 Entry Number: 0
+[MPF, MPImage2, Image] 14 - Dependent Image 2 Entry Number: 0
+[MPF, MPImage2, Preview] PreviewImage - Preview Image: (Binary data 1039273 bytes)
+[Meta, MetaIFD, Image] 50000 - Film Product Code: 37
+[Meta, MetaIFD, Image] 50001 - Image Source EK: 1
+[Meta, MetaIFD, Image] 50002 - Capture Conditions PAR: 1
+[Meta, MetaIFD, Image] 50009 - Frame Number: 0
+[Meta, MetaIFD, Image] 50010 - Film Category: 2
+[Meta, MetaIFD, Image] 50011 - Film Gencode: 2
+[Meta, MetaIFD, Image] 50012 - Model And Version: Version 9
+[Meta, MetaIFD, Image] 50013 - Film Size: 1
+[Meta, MetaIFD, Image] 50014 - SBA RGB Shifts: 0 0 0
+[Meta, MetaIFD, Image] 50015 - SBA Input Image Colorspace: 3
+[Meta, MetaIFD, Image] 50016 - SBA Input Image Bit Depth: 12 12 12
+[Meta, MetaIFD, Image] 50017 - SBA Exposure Record: (Binary data 368 bytes)
+[Meta, MetaIFD, Image] 50018 - User Adj SBA RGB Shifts: (Binary data 5 bytes)
+[Meta, MetaIFD, Image] 50019 - Image Rotation Status: 0
+[Meta, MetaIFD, Image] 50020 - Roll Guid Elements: 00000000000000000000000000000000
+[Meta, MetaIFD, Image] 50021 - Metadata Number: 0100
+[APP5, RMETA, Image] Sign type - Sign Type: Information
+[APP5, RMETA, Image] Location - Location: Roundabout
+[APP5, RMETA, Image] Lit - Lit: No
+[APP5, RMETA, Image] Condition - Condition: Good
+[APP5, RMETA, Image] Azimuth - Azimuth: E
+[PrintIM, PrintIM, Printing] PrintIMVersion - PrintIM Version: 0250
+[APP6, NITF, Image] 0 - NITF Version: 2.00
+[APP6, NITF, Image] 2 - Image Format: IMode B
+[APP6, NITF, Image] 3 - Blocks Per Row: 1
+[APP6, NITF, Image] 5 - Blocks Per Column: 1
+[APP6, NITF, Image] 7 - Image Color: Monochrome
+[APP6, NITF, Image] 8 - Bit Depth: 8
+[APP6, NITF, Image] 9 - Image Class: General Purpose
+[APP6, NITF, Image] 10 - JPEG Process: Baseline sequential DCT, Huffman coding, 8-bit samples
+[APP6, NITF, Image] 11 - Quality: 1
+[APP6, NITF, Image] 12 - Stream Color: Monochrome
+[APP6, NITF, Image] 13 - Stream Bit Depth: 8
+[APP6, NITF, Image] 14 - Flags: 0x1010000
+[XML, MediaJukebox, Image] Tool_Name - Tool Name: Media Center
+[XML, MediaJukebox, Image] Tool_Version - Tool Version: 19.0.67
+[XML, MediaJukebox, Image] People - People: Santa
+[XML, MediaJukebox, Image] Places - Places: Jamaica
+[XML, MediaJukebox, Time] Date - Date: 2013:09:01 20:12:19
+[XML, MediaJukebox, Image] Album - Album: 2013-09-01
+[XML, MediaJukebox, Image] Name - Name: Glass home at night
+[APP11, JPEG-HDR, Image] ver - JPEG-HDR Version: 11
+[APP11, JPEG-HDR, Image] ln0 - Ln0: 0.122262
+[APP11, JPEG-HDR, Image] ln1 - Ln1: 2.634655
+[APP11, JPEG-HDR, Image] s2n - S2n: 2.269635e+03
+[APP11, JPEG-HDR, Image] alp - Alpha: 1.000000
+[APP11, JPEG-HDR, Image] bet - Beta: 1.000000
+[APP11, JPEG-HDR, Image] cor - Correction Method: 0
+[APP11, JPEG-HDR, Preview] RatioImage - Ratio Image: (Binary data 19 bytes)
+[APP12, PictureInfo, Time] TimeDate - Date/Time Original: 1998:12:31 15:17:20
+[APP12, PictureInfo, Image] Shutter - Exposure Time: 1/155
+[APP12, PictureInfo, Image] Flash - Flash: Off
+[APP12, PictureInfo, Image] Resolution - Resolution: 5
+[APP12, PictureInfo, Image] Protect - Protect: 0
+[APP12, PictureInfo, Image] ContTake - Cont Take: 0
+[APP12, PictureInfo, Image] ImageSize - Image Size: 1280x960
+[APP12, PictureInfo, Image] ColorMode - Color Mode: 1
+[APP12, PictureInfo, Image] FNumber - F Number: 11.0
+[APP12, PictureInfo, Image] Zoom - Zoom: 2.1
+[APP12, PictureInfo, Image] Macro - Macro: Off
+[APP12, PictureInfo, Image] LightS - Light S: 0
+[APP12, PictureInfo, Image] ExpBias - Exposure Compensation: +2.0
+[APP12, PictureInfo, Camera] Type - Camera Type: SR84
+[APP12, PictureInfo, Camera] Serial# - Serial Number: #00000001
+[APP12, PictureInfo, Camera] Version - Version: v84-71
+[APP12, PictureInfo, Camera] ID - ID: AGFA DIGITAL CAMERA
+[APP12, PictureInfo, Image] PicLen - Pic Len: 561039
+[APP12, PictureInfo, Image] ThmLen - Thm Len: 3802
+[APP12, PictureInfo, Image] Q - Tag Q: 96
+[APP12, PictureInfo, Image] R - Tag R: 293
+[APP12, PictureInfo, Image] B - Tag B: 332
+[APP12, PictureInfo, Image] s0 - S0: 1e8,0,11b0,6f72,15cf,4225,4225,1050000,a1e0004,0,2f0030d,2f102c5,2880090,0,0
+[APP12, PictureInfo, Image] T0 - T0: 11b15600,1290000,e00c0f,2,0,0
+[Ducky, Ducky, Image] 1 - Quality: 84%
+[Ducky, Ducky, Author] 3 - Copyright: Copyright 2004 Phil Harvey
+[IPTC, IPTC, Other] 0 - Application Record Version: 2
+[IPTC, IPTC, Other] 120 - Caption-Abstract: A witty caption
+[IPTC, IPTC, Author] 122 - Writer-Editor: I wrote it
+[IPTC, IPTC, Other] 105 - Headline: No headline
+[IPTC, IPTC, Other] 40 - Special Instructions: What instructions
+[IPTC, IPTC, Author] 80 - By-line: Phil Harvey
+[IPTC, IPTC, Author] 85 - By-line Title: My Position
+[IPTC, IPTC, Author] 110 - Credit: My Credit
+[IPTC, IPTC, Other] 5 - Object Name: Test IPTC picture
+[IPTC, IPTC, Time] 55 - Date Created: 2004:02:26
+[IPTC, IPTC, Location] 90 - City: Kingston
+[IPTC, IPTC, Location] 95 - Province-State: Ont
+[IPTC, IPTC, Location] 101 - Country-Primary Location Name: Canada
+[IPTC, IPTC, Other] 103 - Original Transmission Reference: What is a transmission reference
+[IPTC, IPTC, Other] 15 - Category: 1
+[IPTC, IPTC, Other] 20 - Supplemental Categories: amazing, image, utilities
+[IPTC, IPTC, Author] 116 - Copyright Notice: Copyright 2004 Phil Harvey
+[IPTC, IPTC, Other] 10 - Urgency: 8 (least urgent)
+[IPTC, IPTC, Author] 115 - Source: I'm the source
+[IPTC, IPTC, Other] 25 - Keywords: jambalaya
+[IPTC, IPTC2, Other] 0 - Application Record Version: 2
+[IPTC, IPTC3, Other] 0 - Application Record Version: 2
+[IPTC, IPTC3, Other] 15 - Category: p
+[IPTC, IPTC3, Time] 55 - Date Created: 2005:12:23
+[IPTC, IPTC3, Other] 5 - Object Name: object name
+[IPTC, IPTC3, Other] 10 - Urgency: 2
+[IPTC, IPTC3, Other] 20 - Supplemental Categories: supp cat
+[IPTC, IPTC3, Other] 40 - Special Instructions: special instructions
+[IPTC, IPTC3, Author] 80 - By-line: byline
+[IPTC, IPTC3, Author] 85 - By-line Title: byline title
+[IPTC, IPTC3, Location] 90 - City: city
+[IPTC, IPTC3, Location] 101 - Country-Primary Location Name: country name
+[IPTC, IPTC3, Other] 103 - Original Transmission Reference: otr
+[IPTC, IPTC3, Other] 105 - Headline: headline
+[IPTC, IPTC3, Author] 110 - Credit: credit
+[IPTC, IPTC3, Author] 115 - Source: source
+[IPTC, IPTC3, Author] 116 - Copyright Notice: copy freely
+[IPTC, IPTC3, Other] 120 - Caption-Abstract: ExifTool AFCP test
+[IPTC, IPTC3, Author] 122 - Writer-Editor: caption writer
+[IPTC, IPTC3, Location] 95 - Province-State: state
+[IPTC, IPTC3, Other] 25 - Keywords: jambalaya
+[Photoshop, Photoshop, Image] 1061 - IPTC Digest: 05ad1770b1a95f1f9788ac995fa647da
+[Photoshop, Photoshop, Image] 0 - X Resolution: 72
+[Photoshop, Photoshop, Image] 2 - Displayed Units X: inches
+[Photoshop, Photoshop, Image] 4 - Y Resolution: 72
+[Photoshop, Photoshop, Image] 6 - Displayed Units Y: inches
+[Photoshop, Photoshop, Image] 0 - Print Style: Centered
+[Photoshop, Photoshop, Image] 2 - Print Position: 0 0
+[Photoshop, Photoshop, Image] 10 - Print Scale: 1
+[Photoshop, Photoshop, Image] 1037 - Global Angle: 30
+[Photoshop, Photoshop, Image] 1049 - Global Altitude: 30
+[Photoshop, Photoshop, Author] 1034 - Copyright Flag: False
+[Photoshop, Photoshop, Author] 1035 - URL: https://exiftool.org/                    
+[Photoshop, Photoshop, Image] 1054 - URL List: 
+[Photoshop, Photoshop, Other] 20 - Slices Group Name: IPTC
+[Photoshop, Photoshop, Other] 24 - Num Slices: 1
+[Photoshop, Photoshop, Image] 4 - Has Real Merged Data: Yes
+[Photoshop, Photoshop, Image] 5 - Writer Name: Adobe Photoshop
+[Photoshop, Photoshop, Image] 9 - Reader Name: Adobe Photoshop 7.0
+[Photoshop, Photoshop, Image] 0 - Photoshop Quality: 7
+[Photoshop, Photoshop, Image] 1 - Photoshop Format: Standard
+[Photoshop, Photoshop, Image] 2 - Progressive Scans: 3 Scans
+[APP13, AdobeCM, Image] 0 - Adobe CM Type: 3
+[APP14, Adobe, Image] 0 - DCT Encode Version: 100
+[APP14, Adobe, Image] 1 - APP14 Flags 0: (none)
+[APP14, Adobe, Image] 2 - APP14 Flags 1: (none)
+[APP14, Adobe, Image] 3 - Color Transform: YCbCr
+[APP15, GraphConv, Image] Q - Quality: 70
+[MIE, MIE-Doc, Author] Copyright - Copyright: © 2006 Phil Harvey
+[MIE, MIE-Main, Other] zmie - Trailer Signature: 
+[PhotoMechanic, PhotoMechanic, Image] 221 - Tagged: Yes
+[PhotoMechanic, PhotoMechanic, Image] 222 - Color Class: 6 (Typical alt)
+[PhotoMechanic, PhotoMechanic, Image] 216 - Rotation: 180
+[PhotoMechanic, PhotoMechanic, Image] 217 - Crop Left: 438
+[PhotoMechanic, PhotoMechanic, Image] 218 - Crop Top: 618
+[PhotoMechanic, PhotoMechanic, Image] 219 - Crop Right: 890
+[PhotoMechanic, PhotoMechanic, Image] 220 - Crop Bottom: 1072
+[CanonVRD, CanonVRD, Image] 2 - VRD Version: 1.0.0
+[CanonVRD, CanonVRD, Image] 6 - WB Adj RGGB Levels: 0 0 0 0
+[CanonVRD, CanonVRD, Image] 24 - White Balance Adj: Shot Settings
+[CanonVRD, CanonVRD, Image] 26 - WB Adj Color Temp: 5600
+[CanonVRD, CanonVRD, Image] 36 - WB Fine Tune Active: No
+[CanonVRD, CanonVRD, Image] 40 - WB Fine Tune Saturation: 0
+[CanonVRD, CanonVRD, Image] 44 - WB Fine Tune Tone: 0
+[CanonVRD, CanonVRD, Image] 46 - Raw Color Adj: Shot Settings
+[CanonVRD, CanonVRD, Image] 48 - Raw Custom Saturation: 0
+[CanonVRD, CanonVRD, Image] 52 - Raw Custom Tone: 0
+[CanonVRD, CanonVRD, Image] 56 - Raw Brightness Adj: 0.00
+[CanonVRD, CanonVRD, Image] 60 - Tone Curve Property: Shot Settings
+[CanonVRD, CanonVRD, Image] 122 - Dynamic Range Min: 0
+[CanonVRD, CanonVRD, Image] 124 - Dynamic Range Max: 4095
+[CanonVRD, CanonVRD, Image] 272 - Tone Curve Active: No
+[CanonVRD, CanonVRD, Image] 275 - Tone Curve Mode: RGB
+[CanonVRD, CanonVRD, Image] 276 - Brightness Adj: 0
+[CanonVRD, CanonVRD, Image] 277 - Contrast Adj: 0
+[CanonVRD, CanonVRD, Image] 278 - Saturation Adj: 100
+[CanonVRD, CanonVRD, Image] 286 - Color Tone Adj: 0
+[CanonVRD, CanonVRD, Image] 294 - Luminance Curve Points: (0,0) (255,255)
+[CanonVRD, CanonVRD, Image] 336 - Luminance Curve Limits: 255 0 255 0
+[CanonVRD, CanonVRD, Image] 345 - Tone Curve Interpolation: Curve
+[CanonVRD, CanonVRD, Image] 352 - Red Curve Points: (0,0) (255,255)
+[CanonVRD, CanonVRD, Image] 394 - Red Curve Limits: 255 0 255 0
+[CanonVRD, CanonVRD, Image] 410 - Green Curve Points: (0,0) (255,255)
+[CanonVRD, CanonVRD, Image] 452 - Green Curve Limits: 255 0 255 0
+[CanonVRD, CanonVRD, Image] 468 - Blue Curve Points: (0,0) (255,255)
+[CanonVRD, CanonVRD, Image] 510 - Blue Curve Limits: 255 0 255 0
+[CanonVRD, CanonVRD, Image] 526 - RGB Curve Points: (0,0) (255,255)
+[CanonVRD, CanonVRD, Image] 568 - RGB Curve Limits: 255 0 255 0
+[CanonVRD, CanonVRD, Image] 580 - Crop Active: No
+[CanonVRD, CanonVRD, Image] 582 - Crop Left: 0
+[CanonVRD, CanonVRD, Image] 584 - Crop Top: 0
+[CanonVRD, CanonVRD, Image] 586 - Crop Width: 0
+[CanonVRD, CanonVRD, Image] 588 - Crop Height: 0
+[CanonVRD, CanonVRD, Image] 602 - Sharpness Adj: 0
+[CanonVRD, CanonVRD, Image] 608 - Crop Aspect Ratio: Free
+[CanonVRD, CanonVRD, Image] 610 - Constrained Crop Width: 0
+[CanonVRD, CanonVRD, Image] 614 - Constrained Crop Height: 0
+[CanonVRD, CanonVRD, Image] 618 - Check Mark: Clear
+[CanonVRD, CanonVRD, Image] 622 - Rotation: 90
+[CanonVRD, CanonVRD, Image] 624 - Work Color Space: sRGB
+[FotoStation, FotoStation, Image] 0 - Original Image Width: 16
+[FotoStation, FotoStation, Image] 1 - Original Image Height: 16
+[FotoStation, FotoStation, Image] 2 - Color Planes: 3
+[FotoStation, FotoStation, Image] 3 - XY Resolution: 9
+[FotoStation, FotoStation, Image] 4 - Rotation: 0
+[FotoStation, FotoStation, Image] 6 - Crop Left: 24.557%
+[FotoStation, FotoStation, Image] 7 - Crop Top: 21.25%
+[FotoStation, FotoStation, Image] 8 - Crop Right: 30.676%
+[FotoStation, FotoStation, Image] 9 - Crop Bottom: 86.25%
+[FotoStation, FotoStation, Image] 11 - Crop Rotation: 0
+[Composite, Composite, Image] Exif::Aperture - Aperture: 3.5
+[Composite, Composite, Image] Exif::ImageSize - Image Size: 8x8
+[Composite, Composite, Image] Exif::Megapixels - Megapixels: 0.000064
+[Composite, Composite, Image] Exif::ShutterSpeed - Shutter Speed: 1/155
+[Composite, Composite, Image] Exif::LightValue - Light Value: 10.9
+[Composite, Composite, Camera] Exif::ScaleFactor35efl - Scale Factor To 35 mm Equivalent: 6.9
+[Composite, Composite, Camera] Exif::CircleOfConfusion - Circle Of Confusion: 0.004 mm
+[Composite, Composite, Image] Exif::FOV - Field Of View: 47.0 deg
+[Composite, Composite, Camera] Exif::FocalLength35efl - Focal Length: 6.0 mm (35 mm equivalent: 41.4 mm)
+[Composite, Composite, Camera] Exif::HyperfocalDistance - Hyperfocal Distance: 2.36 m


### PR DESCRIPTION
An object which stringifies to a file path should work as a file path string: it can be manipulated as an object, but for anything which simply requires a string, it behaves as one. Cpan modules `Path::Tiny` and `Path::Class` provide such objects.

Unfortunately these currently don't work with `Image::ExifTool`: it detects that the filenames are references and treats them specially, rather than just as strings. For instance:

    $ perl -MImage::ExifTool -MPath::Tiny -wE 'say Image::ExifTool->new->ImageInfo(path "t/images/ExifTool.jpg")->{Artist}'
    Don't understand ImageInfo argument t/images/ExifTool.jpg
    Use of uninitialized value in say at -e line 1.

That's particularly awkward because the overloaded stringification *is* used in the warning, meaning that it appears to be complaining about being passed a perfectly cromulent filename!

As a user this can be worked round by explicitly stringifying the path before it is passed to `ImageInfo`, for instance by prepending it with the empty string:

    $ perl -MImage::ExifTool -MPath::Tiny -wE 'say Image::ExifTool->new->ImageInfo("".path "t/images/ExifTool.jpg")->{Artist}'
    Phil Harvey

It's nicer to not force users to do this, as well as being safer. (Code like `ImageInfo(" $file")` risks somebody spotting that the quote marks are redundant round a Perl variable and removing them!)

The attached patch simply looks for overloaded stringification on an input argument, and if found, simply treats it as a string, as the object intended.

All existing tests still pass, and I've added a new one to test the new behaviour. This uses a trivial string-overloading class in the `.t` file, to avoid an external dependency on `Path::Tiny` or similar.

The new test re-uses the image and output from test 2 (just passing the filename differently). It adds  `t/ExifTool_32.out` as a copy of ` t/ExifTool_2.out`. That seemed the best option for keeping the tests simple. Alternatives would be to test less with the file object, not doing a full `check()`, or to invoke test 32's `check()` with a hard-coded `2` instead of `$testnum`.

Cheers