### PR TITLE
Fix overwrite_original_in_place file open mode

### DIFF
--- a/exiftool
+++ b/exiftool
@@ -3061,12 +3061,13 @@ sub SetImageInfo($$$)
                         # temporarily disable CTRL-C during this critical operation
                         $critical = 1;
                         undef $tmpFile;     # handle deletion of temporary file ourself
-                        if ($et->Open(\*ORIG_FILE, $file, '>')) {
+                        if ($et->Open(\*ORIG_FILE, $file, '+<')) {
                             binmode(ORIG_FILE);
                             while (read(NEW_FILE, $buff, 65536)) {
                                 print ORIG_FILE $buff or $err = 1;
                             }
                             close(NEW_FILE);
+                            truncate(ORIG_FILE, tell(ORIG_FILE));  # Handle files being shorter than the original
                             close(ORIG_FILE) or $err = 1;
                             if ($err) {
                                 Warn "Couldn't overwrite in place - $file\n";

--- a/windows_exiftool
+++ b/windows_exiftool
@@ -3052,12 +3052,13 @@ sub SetImageInfo($$$)
                         # temporarily disable CTRL-C during this critical operation
                         $critical = 1;
                         undef $tmpFile;     # handle deletion of temporary file ourself
-                        if ($et->Open(\*ORIG_FILE, $file, '>')) {
+                        if ($et->Open(\*ORIG_FILE, $file, '+<')) {
                             binmode(ORIG_FILE);
                             while (read(NEW_FILE, $buff, 65536)) {
                                 print ORIG_FILE $buff or $err = 1;
                             }
                             close(NEW_FILE);
+                            truncate(ORIG_FILE, tell(ORIG_FILE));  # Handle files being shorter than the original
                             close(ORIG_FILE) or $err = 1;
                             if ($err) {
                                 Warn "Couldn't overwrite in place - $file\n";


### PR DESCRIPTION
The documentation states that overwrite_original_in_place opens a file
in update mode:

> This is implemented by opening the original file in update mode and
> replacing its data with a copy of a temporary file before deleting the
> temporary.

This makes the code behave as described.