### PR TITLE
Fix Sony Tag9403 CameraTemperature condition

### DIFF
--- a/lib/Image/ExifTool/Sony.pm
+++ b/lib/Image/ExifTool/Sony.pm
@@ -8382,7 +8382,7 @@ my %isoSetting2010 = (
     },
     0x05 => {
         Name => 'CameraTemperature', # (maybe SensorTemperature? - heats up when taking movies)
-        Condition => '$$self{TempTest2} and $$self{TempTest2} < 100',
+        Condition => '$$self{TempTest2} and $$self{TempTest2} != 0 and $$self{TempTest2} != 148',
         Format => 'int8s', # have seen as low as -1 for AmbientTemperature of -18
         PrintConv => '"$val C"',
         PrintConvInv => '$val=~s/ ?C//; $val',


### PR DESCRIPTION
Comment in TempTest2 states:
```
# seen values 0,2,3,18,32,49,50,83,148
# CameraTemperature is valid for all values except 0,148
```
however CameraTemperature was not using this.

Fix adds this condition to CameraTemperature.

An example of `TempTest2 == 0`, is `SonyNEX-6.jpg` in the [ExifTool JPEG samples](https://exiftool.org/Sony.tar.gz).