### PR TITLE
Fix typo in Matroska projection tags

### DIFF
--- a/lib/Image/ExifTool/Matroska.pm
+++ b/lib/Image/ExifTool/Matroska.pm
@@ -664,6 +664,7 @@ my %noYes = ( 0 => 'No', 1 => 'Yes' );
             3 => 'Mesh',
         },
     },
+    # ProjectionPrivate in the spec
     0x7672 => [{
         Name => 'EquirectangularProj',
         Condition => '$$self{ProjectionType} == 1',

--- a/lib/Image/ExifTool/Matroska.pm
+++ b/lib/Image/ExifTool/Matroska.pm
@@ -673,9 +673,9 @@ my %noYes = ( 0 => 'No', 1 => 'Yes' );
         Condition => '$$self{ProjectionType} == 2',
         SubDirectory => { TagTable => 'Image::ExifTool::QuickTime::cbmp' },
     }],
-    0x7673 => { Name => 'ProjectionPosYaw',   Format => 'float' },
-    0x7674 => { Name => 'ProjectionPosPitch', Format => 'float' },
-    0x7675 => { Name => 'ProjectionPosRoll',  Format => 'float' },
+    0x7673 => { Name => 'ProjectionPoseYaw',   Format => 'float' },
+    0x7674 => { Name => 'ProjectionPosePitch', Format => 'float' },
+    0x7675 => { Name => 'ProjectionPoseRoll',  Format => 'float' },
 );
 
 #------------------------------------------------------------------------------

--- a/lib/Image/ExifTool/TagNames.pod
+++ b/lib/Image/ExifTool/TagNames.pod
@@ -29294,9 +29294,9 @@ for the specification.
   0x7671   ProjectionType                       no
   0x7672   EquirectangularProj                  QuickTime equi
            CubemapProj                          QuickTime cbmp
-  0x7673   ProjectionPosYaw                     no
-  0x7674   ProjectionPosPitch                   no
-  0x7675   ProjectionPosRoll                    no
+  0x7673   ProjectionPoseYaw                    no
+  0x7674   ProjectionPosePitch                  no
+  0x7675   ProjectionPoseRoll                   no
 
 =head2 MOI Tags
 


### PR DESCRIPTION
There was a missing 'e' in several tags e.g., ProjectionPos**e**Yaw.

Cheers,
Martin