### PR TITLE
add DriveSerialNumber to LNK parser

### DIFF
--- a/lib/Image/ExifTool/LNK.pm
+++ b/lib/Image/ExifTool/LNK.pm
@@ -273,7 +273,11 @@ sub ProcessLinkInfo($$$);
             6 => 'Ram Disk',
         },
     },
-    DriveSerialNumber => { },
+    DriveSerialNumber => {
+        PrintConv => {
+            OTHER => sub { join("-", unpack("A4 A4", sprintf("%08X", $_[0]))) },
+        },
+    },
     VolumeLabel => { },
     LocalBasePath => { },
     CommonNetworkRelLink => { },
@@ -508,6 +512,7 @@ sub ProcessLinkInfo($$$)
         if ($off + 0x20 <= $dataLen) {
             # my $len = Get32u($dataPt, $off);
             $et->HandleTag($tagTablePtr, 'DriveType', undef, %opts, Start=>$off+4);
+            $et->HandleTag($tagTablePtr, 'DriveSerialNumber', undef, %opts, Start=>$off+8);
             $pos = Get32u($dataPt, $off + 0x0c);
             if ($pos == 0x14) {
                 # use VolumeLabelOffsetUnicode instead

--- a/t/LNK_2.out
+++ b/t/LNK_2.out
@@ -20,6 +20,7 @@
 [LNK, LNK, Other] 64 - Hot Key: (none)
 [LNK, LNK, Other] 14 - Target File DOS Name: EXIFTO~2.EXE
 [LNK, LNK, Other] DriveType - Drive Type: Fixed Disk
+[LNK, LNK, Other] DriveSerialNumber - Drive Serial Number: C8F0-D326
 [LNK, LNK, Other] VolumeLabel - Volume Label: 
 [LNK, LNK, Other] LocalBasePath - Local Base Path: C:\Documents and Settings\Phil\Desktop\exiftool(-k).exe
 [LNK, LNK, Other] 196612 - Description: Rename file name with image date and time


### PR DESCRIPTION
This commit adds the Drive Serial Number field to the LNK parser (actually it looks like there was a placeholder for it already but it was never implemented).