### PR TITLE
Remove indirect object notation in synopsis

### DIFF
--- a/lib/Image/ExifTool.pod
+++ b/lib/Image/ExifTool.pod
@@ -26,7 +26,7 @@ Image::ExifTool - Read and write meta information
   # ---- Object-oriented usage ----
 
   # Create a new Image::ExifTool object
-  $exifTool = new Image::ExifTool;
+  $exifTool = Image::ExifTool->new;
 
   # Extract meta information from an image
   $exifTool->ExtractInfo($file, \%options);


### PR DESCRIPTION
Perl starting with v5.36 is moving away from indirect object notation (`new Class`) being on by default, so I adjusted the synopsis example. No big whoop.

And, thanks for exiftool. I've been using it this week to go through tens of thousands of images to adjust their original creation dates. I have no idea why my camera was 4 hours and 26 minutes off.