### PR TITLE
[WIP] Added support for InfiRay's IJPEG images

### DIFF
--- a/lib/Image/ExifTool.pm
+++ b/lib/Image/ExifTool.pm
@@ -6335,7 +6335,7 @@ sub ProcessJPEG($$)
     my %dumpParms = ( Out => $out );
     my ($success, $wantTrailer, $trailInfo, $foundSOS, %jumbfChunk);
     my (@iccChunk, $iccChunkCount, $iccChunksTotal, @flirChunk, $flirCount, $flirTotal);
-    my ($preview, $scalado, @dqt, $subSampling, $dumpEnd, %extendedXMP);
+    my ($preview, $scalado, @dqt, $subSampling, $dumpEnd, %extendedXMP, $infiray);
 
     # check to be sure this is a valid JPG (or J2C, or EXV) file
     return 0 unless $raf->Read($s, 2) == 2 and $s =~ /^\xff[\xd8\x4f\x01]/;
@@ -6939,7 +6939,7 @@ sub ProcessJPEG($$)
                 $dumpType = 'Preview Image';
                 $preview = substr($$segDataPt, length($1));
             } elsif ($$segDataPt =~ /^....IJPEG\0/) {
-                $self->OverrideFileType('IJPEG') if $$self{FILE_TYPE} eq 'JPEG';
+				$infiray = 1;
                 $dumpType = 'InfiRay Version';
                 SetByteOrder('II');
                 my $tagTablePtr = GetTagTable('Image::ExifTool::InfiRay::Version');
@@ -7004,7 +7004,7 @@ sub ProcessJPEG($$)
                 undef $preview;
             }
         } elsif ($marker == 0xe4) {         # APP4 (InfiRay, "SCALADO", FPXR, PreviewImage)
-            if ($$self{FileType} eq 'IJPEG' and $length >= 120) {
+            if ($infiray and $length >= 120) {
                 $dumpType = 'InfiRay FactoryTemp';
                 SetByteOrder('II');
                 my $tagTablePtr = GetTagTable('Image::ExifTool::InfiRay::FactoryTemp');
@@ -7051,7 +7051,7 @@ sub ProcessJPEG($$)
                 undef $preview;
             }
         } elsif ($marker == 0xe5) {         # APP5 (Ricoh "RMETA")
-            if ($$self{FileType} eq 'IJPEG' and $length >= 38) {
+            if ($infiray and $length >= 38) {
                 $dumpType = 'InfiRay PictureTemp';
                 SetByteOrder('II');
                 my $tagTablePtr = GetTagTable('Image::ExifTool::InfiRay::PictureTemp');
@@ -7077,7 +7077,7 @@ sub ProcessJPEG($$)
                 undef $preview;
             }
         } elsif ($marker == 0xe6) {         # APP6 (Toshiba EPPIM, NITF, HP_TDHD)
-            if ($$self{FileType} eq 'IJPEG' and $length >= 129) {
+            if ($infiray and $length >= 129) {
                 $dumpType = 'InfiRay MixMode';
                 SetByteOrder('II');
                 my $tagTablePtr = GetTagTable('Image::ExifTool::InfiRay::MixMode');
@@ -7116,7 +7116,7 @@ sub ProcessJPEG($$)
                 $self->HandleTag($tagTablePtr, 'APP6', $$segDataPt);
             }
         } elsif ($marker == 0xe7) {         # APP7 (Pentax, Huawei, Qualcomm)
-            if ($$self{FileType} eq 'IJPEG' and $length >= 32) {
+            if ($infiray and $length >= 32) {
                 $dumpType = 'InfiRay OperationMode';
                 SetByteOrder('II');
                 my $tagTablePtr = GetTagTable('Image::ExifTool::InfiRay::OperationMode');
@@ -7161,7 +7161,7 @@ sub ProcessJPEG($$)
                 $self->ProcessDirectory(\%dirInfo, $tagTablePtr);
             }
         } elsif ($marker == 0xe8) {         # APP8 (SPIFF)
-            if ($$self{FileType} eq 'IJPEG' and $length >= 32) {
+            if ($infiray and $length >= 32) {
                 $dumpType = 'InfiRay Isothermal';
                 SetByteOrder('II');
                 my $tagTablePtr = GetTagTable('Image::ExifTool::InfiRay::Isothermal');
@@ -7174,7 +7174,7 @@ sub ProcessJPEG($$)
                 $self->ProcessDirectory(\%dirInfo, $tagTablePtr);
             }
         } elsif ($marker == 0xe9) {         # APP9 (InfiRay, Media Jukebox)
-            if ($$self{FileType} eq 'IJPEG' and $length >= 768) {
+            if ($infiray and $length >= 768) {
                 $dumpType = 'InfiRay SensorInfo';
                 SetByteOrder('II');
                 my $tagTablePtr = GetTagTable('Image::ExifTool::InfiRay::SensorInfo');

--- a/lib/Image/ExifTool.pm
+++ b/lib/Image/ExifTool.pm
@@ -6938,6 +6938,10 @@ sub ProcessJPEG($$)
                 # Digilife DDC-690/Rollei="BGTH"
                 $dumpType = 'Preview Image';
                 $preview = substr($$segDataPt, length($1));
+            } elsif ($$segDataPt =~ /^....IJPEG\0/) {
+                SetByteOrder('II');
+                my $tagTablePtr = GetTagTable('Image::ExifTool::JPEG::Main');
+                $self->HandleTag($tagTablePtr, 'APP2', $$segDataPt);
             } elsif ($preview) {
                 $dumpType = 'Preview Image';
                 $preview .= $$segDataPt;

--- a/lib/Image/ExifTool.pm
+++ b/lib/Image/ExifTool.pm
@@ -7077,7 +7077,12 @@ sub ProcessJPEG($$)
                 undef $preview;
             }
         } elsif ($marker == 0xe6) {         # APP6 (Toshiba EPPIM, NITF, HP_TDHD)
-            if ($$segDataPt =~ /^EPPIM\0/) {
+            if ($$self{FileType} eq 'IJPEG' and $length >= 129) {
+                $dumpType = 'InfiRay MixMode';
+                SetByteOrder('II');
+                my $tagTablePtr = GetTagTable('Image::ExifTool::InfiRay::MixMode');
+                $self->ProcessDirectory(\%dirInfo, $tagTablePtr);
+            } elsif ($$segDataPt =~ /^EPPIM\0/) {
                 undef $dumpType;    # (will be dumped here)
                 DirStart(\%dirInfo, 6, 6);
                 if ($htmlDump) {
@@ -7111,7 +7116,12 @@ sub ProcessJPEG($$)
                 $self->HandleTag($tagTablePtr, 'APP6', $$segDataPt);
             }
         } elsif ($marker == 0xe7) {         # APP7 (Pentax, Huawei, Qualcomm)
-            if ($$segDataPt =~ /^PENTAX \0(II|MM)/) {
+            if ($$self{FileType} eq 'IJPEG' and $length >= 32) {
+                $dumpType = 'InfiRay OperationMode';
+                SetByteOrder('II');
+                my $tagTablePtr = GetTagTable('Image::ExifTool::InfiRay::OperationMode');
+                $self->ProcessDirectory(\%dirInfo, $tagTablePtr);
+            } elsif ($$segDataPt =~ /^PENTAX \0(II|MM)/) {
                 # found in K-3 images (is this multi-segment??)
                 SetByteOrder($1);
                 undef $dumpType; # (dump this ourself)
@@ -7151,8 +7161,13 @@ sub ProcessJPEG($$)
                 $self->ProcessDirectory(\%dirInfo, $tagTablePtr);
             }
         } elsif ($marker == 0xe8) {         # APP8 (SPIFF)
+            if ($$self{FileType} eq 'IJPEG' and $length >= 32) {
+                $dumpType = 'InfiRay Isothermal';
+                SetByteOrder('II');
+                my $tagTablePtr = GetTagTable('Image::ExifTool::InfiRay::Isothermal');
+                $self->ProcessDirectory(\%dirInfo, $tagTablePtr);
             # my sample SPIFF has 32 bytes of data, but spec states 30
-            if ($$segDataPt =~ /^SPIFF\0/ and $length == 32) {
+            } elsif ($$segDataPt =~ /^SPIFF\0/ and $length == 32) {
                 $dumpType = 'SPIFF';
                 DirStart(\%dirInfo, 6);
                 my $tagTablePtr = GetTagTable('Image::ExifTool::JPEG::SPIFF');

--- a/lib/Image/ExifTool/InfiRay.pm
+++ b/lib/Image/ExifTool/InfiRay.pm
@@ -21,15 +21,20 @@ my %convFloat2 = (
 );
 
 my %convPercentage = (
-    PrintConv => 'sprintf("%.1f%%", $val * 100)',
+    PrintConv => 'sprintf("%.1f %%", $val * 100)',
 );
 
 my %convMeters = (
-    PrintConv => 'sprintf("%.2fm", $val)',
+    PrintConv => 'sprintf("%.2f m", $val / 128)',
 );
 
 my %convCelsius = (
-    PrintConv => 'sprintf("%.2fºC", $val)',
+    PrintConv => 'sprintf("%.2f C", $val)',
+);
+
+my %bool = (
+	Format => 'int8u',
+	PrintConv => { 0 => 'No', 1 => 'Yes' }
 );
 
 # InfiRay IJPEG version header, found in JPEGs APP2
@@ -46,7 +51,7 @@ my %convCelsius = (
     0x0d => { Name => 'IJPEGDispType',        Format => 'int8u' },
     0x0e => { Name => 'IJPEGRotate',          Format => 'int8u' },
     0x0f => { Name => 'IJPEGMirrorFlip',      Format => 'int8u' },
-    0x10 => { Name => 'ImageColorSwitchable', Format => 'int8u' },
+    0x10 => { Name => 'ImageColorSwitchable', %bool },
     0x11 => { Name => 'ThermalColorPalette',  Format => 'int16u' },
     0x20 => { Name => 'IRDataSize',           Format => 'int64u' },
     0x28 => { Name => 'IRDataFormat',         Format => 'int16u' },
@@ -89,9 +94,9 @@ my %convCelsius = (
     0x44 => { Name => 'FactRelSensorTemp',  Format => 'int16s' },
     0x46 => { Name => 'FactRelShutterTemp', Format => 'int16s' },
     0x48 => { Name => 'FactRelLensTemp',    Format => 'int16s' },
-    0x64 => { Name => 'FactStatusGain',     Format => 'int8s' },
-    0x65 => { Name => 'FactStatusEnvOK',    Format => 'int8s' },
-    0x66 => { Name => 'FactStatusDistOK',   Format => 'int8s' },
+    0x64 => { Name => 'FactStatusGainOK',   %bool },
+    0x65 => { Name => 'FactStatusEnvOK',    %bool },
+    0x66 => { Name => 'FactStatusDistOK',   %bool },
     0x67 => { Name => 'FactStatusTempMap',  Format => 'int8s' },
     # Missing: ndist_table_len, ndist_table, nuc_t_table_len, nuc_t_table
 );
@@ -104,15 +109,15 @@ my %convCelsius = (
         This table lists tags found in the InfiRay IJPEG picture temperature
         information.
     },
-    0x00 => { Name => 'EnvironmentTemp', Format => 'float', %convCelsius },
-    0x04 => { Name => 'Distance', Format => 'float', %convMeters },
-    0x08 => { Name => 'Emissivity', Format => 'float', %convFloat2 },
-    0x0c => { Name => 'Humidity', Format => 'float', %convPercentage },
-    0x10 => { Name => 'ReferenceTemp', Format => 'float', %convCelsius },
-    0x20 => { Name => 'TempUnit', Format => 'int8u' },
-    0x21 => { Name => 'ShowCenterTemp', Format => 'int8u' },
-    0x22 => { Name => 'ShowMaxTemp', Format => 'int8u' },
-    0x23 => { Name => 'ShowMinTemp', Format => 'int8u' },
+    0x00 => { Name => 'EnvironmentTemp',  Format => 'float', %convCelsius },
+    0x04 => { Name => 'Distance',         Format => 'float', %convMeters },
+    0x08 => { Name => 'Emissivity',       Format => 'float', %convFloat2 },
+    0x0c => { Name => 'Humidity',         Format => 'float', %convPercentage },
+    0x10 => { Name => 'ReferenceTemp',    Format => 'float', %convCelsius },
+    0x20 => { Name => 'TempUnit',         Format => 'int8u' },
+    0x21 => { Name => 'ShowCenterTemp',   %bool },
+    0x22 => { Name => 'ShowMaxTemp',      %bool },
+    0x23 => { Name => 'ShowMinTemp',      %bool },
     0x24 => { Name => 'TempMeasureCount', Format => 'int16u' },
     # TODO: process extra measurements list
 );
@@ -125,10 +130,10 @@ my %convCelsius = (
         This table lists tags found in the InfiRay IJPEG visual-infrared
         mixing mode section.
     },
-    0x00 => { Name => 'MixMode', Format => 'int8u' },
-    0x01 => { Name => 'FusionIntensity', Format => 'float', %convPercentage },
+    0x00 => { Name => 'MixMode',          Format => 'int8u' },
+    0x01 => { Name => 'FusionIntensity',  Format => 'float', %convPercentage },
     0x05 => { Name => 'OffsetAdjustment', Format => 'float' },
-    0x09 => { Name => 'CorrectionAsix', Format => 'float[30]' },
+    0x09 => { Name => 'CorrectionAsix',   Format => 'float[30]' },
 );
 
 # InfiRay IJPEG camera operation mode, found in IJPEG's APP7 section
@@ -141,12 +146,12 @@ my %convCelsius = (
         This table lists tags found in the InfiRay IJPEG camera operation
         mode section.
     },
-    0x00 => { Name => 'WorkingMode', Format => 'int8u' },
-    0x01 => { Name => 'IntegralTime', Format => 'int32u' },
-    0x05 => { Name => 'IntegratTimeHdr',  Format => 'int32u' },
-    0x09 => { Name => 'GainStable',  Format => 'int8u' },
-    0x0a => { Name => 'TempControlEnable',  Format => 'int8u' },
-    0x0b => { Name => 'DeviceTemp',  Format => 'float', %convCelsius },
+    0x00 => { Name => 'WorkingMode',       Format => 'int8u' },
+    0x01 => { Name => 'IntegralTime',      Format => 'int32u' },
+    0x05 => { Name => 'IntegratTimeHdr',   Format => 'int32u' },
+    0x09 => { Name => 'GainStable',        %bool },
+    0x0a => { Name => 'TempControlEnable', %bool },
+    0x0b => { Name => 'DeviceTemp',        Format => 'float', %convCelsius },
 );
 
 # InfiRay IJPEG isothermal information, found in IJPEG's APP8 section

--- a/lib/Image/ExifTool/InfiRay.pm
+++ b/lib/Image/ExifTool/InfiRay.pm
@@ -117,6 +117,55 @@ my %convCelsius = (
     # TODO: process extra measurements list
 );
 
+# InfiRay IJPEG visual-infrared mixing mode, found in IJPEG's APP6 section
+%Image::ExifTool::InfiRay::MixMode = (
+    GROUPS => { 2 => 'Image' },
+    PROCESS_PROC => \&Image::ExifTool::ProcessBinaryData,
+    NOTES => q{
+        This table lists tags found in the InfiRay IJPEG visual-infrared
+        mixing mode section.
+    },
+    0x00 => { Name => 'MixMode', Format => 'int8u' },
+    0x01 => { Name => 'FusionIntensity', Format => 'float', %convPercentage },
+    0x05 => { Name => 'OffsetAdjustment', Format => 'float' },
+    0x09 => { Name => 'CorrectionAsix', Format => 'float[30]' },
+);
+
+# InfiRay IJPEG camera operation mode, found in IJPEG's APP7 section
+#
+# I do not know in what units these times are, or what do they represent.
+%Image::ExifTool::InfiRay::OperationMode = (
+    GROUPS => { 2 => 'Image' },
+    PROCESS_PROC => \&Image::ExifTool::ProcessBinaryData,
+    NOTES => q{
+        This table lists tags found in the InfiRay IJPEG camera operation
+        mode section.
+    },
+    0x00 => { Name => 'WorkingMode', Format => 'int8u' },
+    0x01 => { Name => 'IntegralTime', Format => 'int32u' },
+    0x05 => { Name => 'IntegratTimeHdr',  Format => 'int32u' },
+    0x09 => { Name => 'GainStable',  Format => 'int8u' },
+    0x0a => { Name => 'TempControlEnable',  Format => 'int8u' },
+    0x0b => { Name => 'DeviceTemp',  Format => 'float', %convCelsius },
+);
+
+# InfiRay IJPEG isothermal information, found in IJPEG's APP8 section
+#
+# I have genuinely no clue what is the meaning of any of this information, or
+# what is it used for.
+%Image::ExifTool::InfiRay::Isothermal = (
+    GROUPS => { 2 => 'Image' },
+    PROCESS_PROC => \&Image::ExifTool::ProcessBinaryData,
+    NOTES => q{
+        This table lists tags found in the InfiRay IJPEG picture isothermal
+        information.
+    },
+    0x00 => { Name => 'IsothermalMax', Format => 'float' },
+    0x04 => { Name => 'IsothermalMin', Format => 'float' },
+    0x08 => { Name => 'ChromaBarMax',  Format => 'float' },
+    0x0c => { Name => 'ChromaBarMin',  Format => 'float' },
+);
+
 # InfiRay IJPEG sensor information, found in IJPEG's APP9 section
 %Image::ExifTool::InfiRay::SensorInfo = (
     GROUPS => { 2 => 'Image' },

--- a/lib/Image/ExifTool/InfiRay.pm
+++ b/lib/Image/ExifTool/InfiRay.pm
@@ -1,0 +1,80 @@
+#------------------------------------------------------------------------------
+# File:         InfiRay.pm
+#
+# Description:  InfiRay IJPEG thermal image metadata
+#
+# Revisions:    2023-02-08 - M. Del Sol Created
+#
+# Notes:        Information in this document has been mostly gathered by
+#				disassembling the P2 Pro Android app, version 1.0.8.230111.
+#------------------------------------------------------------------------------
+
+package Image::ExifTool::InfiRay;
+
+use strict;
+use vars qw($VERSION);
+
+$VERSION = '1.00';
+
+# InfiRay IJPEG version header, found in JPEGs APP2
+%Image::ExifTool::InfiRay::Version = (
+    GROUPS => { 2 => 'Image' },
+    PROCESS_PROC => \&Image::ExifTool::ProcessBinaryData,
+    NOTES => q{
+        This table lists tags found in the InfiRay IJPEG version header, found
+		in JPEGs taken with the P2 Pro camera app.
+    },
+    0x00 => { Name => 'Version',              Format => 'int8u[4]' },
+    0x04 => { Name => 'Signature',            Format => 'string' },
+    0x0c => { Name => 'ImageOrgType',         Format => 'int8u' },
+    0x0d => { Name => 'ImageDispType',        Format => 'int8u' },
+    0x0e => { Name => 'ImageRotate',          Format => 'int8u' },
+    0x0f => { Name => 'ImageMirrorFlip',      Format => 'int8u' },
+    0x10 => { Name => 'ImageColorSwitchable', Format => 'int8u' },
+    0x11 => { Name => 'ImageColorPalette',    Format => 'int16u' },
+    0x20 => { Name => 'IRDataSize',           Format => 'int64u' },
+    0x28 => { Name => 'IRDataFormat',         Format => 'int16u' },
+    0x2a => { Name => 'IRImageWidth',         Format => 'int16u' },
+    0x2c => { Name => 'IRImageHeight',        Format => 'int16u' },
+    0x2e => { Name => 'IRImageBpp',           Format => 'int8u' },
+    0x30 => { Name => 'TempDataSize',         Format => 'int64u' },
+    0x38 => { Name => 'TempDataFormat',       Format => 'int16u' },
+    0x3a => { Name => 'TempImageWidth',       Format => 'int16u' },
+    0x3c => { Name => 'TempImageHeight',      Format => 'int16u' },
+    0x3e => { Name => 'TempImageBpp',         Format => 'int8u' },
+    0x40 => { Name => 'VisibleDataSize',      Format => 'int64u' },
+    0x48 => { Name => 'VisibleDataFormat',    Format => 'int16u' },
+    0x4a => { Name => 'VisibleImageWidth',    Format => 'int16u' },
+    0x4c => { Name => 'VisibleImageHeight',   Format => 'int16u' },
+    0x4e => { Name => 'VisibleImageBpp',      Format => 'int8u' },
+);
+
+__END__
+
+=head1 NAME
+
+Image::ExifTool::InfiRay - InfiRay IJPEG thermal image metadata
+
+=head1 SYNOPSIS
+
+This module is loaded automatically by Image::ExifTool when required.
+
+=head1 DESCRIPTION
+
+This module contains definitions required by Image::ExifTool to interpret
+metadata and thermal-related information of pictures saved by the InfiRay
+IJPEG SDK, used in cameras such as the P2 Pro.
+
+=head1 AUTHOR
+
+Copyright 2003-2023, Marcos Del Sol Vives (marcos at orca.pet)
+
+This library is free software; you can redistribute it and/or modify it
+under the same terms as Perl itself.
+
+=head1 SEE ALSO
+
+L<Image::ExifTool::TagNames/InfiRay Tags>,
+L<Image::ExifTool(3pm)|Image::ExifTool>
+
+=cut

--- a/lib/Image/ExifTool/JPEG.pm
+++ b/lib/Image/ExifTool/JPEG.pm
@@ -87,6 +87,10 @@ sub ProcessJPEG_HDR($$$);
         Name => 'PreviewImage',
         Condition => '$$valPt =~ /^(|QVGA\0|BGTH)\xff\xd8\xff\xdb/',
         Notes => 'Samsung APP2 preview image', # (Samsung/GoPro="", BenQ="QVGA\0", Digilife="BGTH")
+      }, {
+        Name => 'IJPEG_Version',
+        Condition => '$$valPt =~ /^....IJPEG\0/',
+        SubDirectory => { TagTable => 'Image::ExifTool::InfiRay::Version' },
     }],
     APP3 => [{
         Name => 'Meta',


### PR DESCRIPTION
Please beware this is my first time coding in Perl, and I am not familiar with the codebase. However I've tried to make it as simmilar to the existing codebase as possible.

InfiRay's thermal imaging cameras generate JPEGs with a plethora of metadata embedded in multiple APPx segments.

These are:
 - APP2: IJPEG version header (`ijpeg_version`)
 - APP3 (multiple in chunks up to 0xFFFE in size): combined IR+thermal+visible data
 - APP4: ? (`fact_temp_param_version`)
 - APP5: Environment temperature (`env_temp`)
 - APP6: ? (`mix_type`)
 - APP7: camera settings (`work_mode`)
 - APP8: ? (`isothermal_max`)
 - APP9: IR/visible light sensor data, such as model, firmware, serial number... (`ir_manufacturer`)

Names in parentheses are the names assigned by the P2 Pro APK `com.infisense.ijpeglibrary.IJpegBean` class.

So far, it seems that some data in these headers is wrong. Namely, in the only supported header so far, the version header, the blob sizes are right but the image height and bpp are not (it lists a height of 384 and 8bpp, while the correct are 192 and 16bpp). Not sure if I should warn or correct this data before printing.

The meaning of some fields is not clear either (ie "image org type"). Not sure what to make of these.

All temperatures (including the raw temperature data blob) are stored in a 64th of a kelvin. Thus to convert a stored temperature value to a kelvin one just needs to multiply by 64.

Sample images:
![1675855475642](https://user-images.githubusercontent.com/515068/217523173-9b2b7c4d-6d69-45f3-9319-764a358d21cb.jpg)
![laptop - copia](https://user-images.githubusercontent.com/515068/217523370-b85d3ae8-d4f6-49e2-bf9e-eb09e066c979.jpg)
