### PR TITLE
Update a few DocumentInfo property IDs

### DIFF
--- a/lib/Image/ExifTool/FlashPix.pm
+++ b/lib/Image/ExifTool/FlashPix.pm
@@ -633,10 +633,10 @@ my %fpxFileType = (
     },
   # 0x18 ? seen -1
   # 0x19 ? seen 0
-  # 0x1a ? seen 0
-  # 0x1b ? seen 0
-  # 0x1c ? seen 0,1
-  # 0x1d ? seen 1
+    0x1a => 'ContentType',
+    0x1b => 'ContentStatus',
+    0x1c => 'Language',
+    0x1d => 'DocVersion',
   # 0x1e ? seen 1
   # 0x1f ? seen 1,5
   # 0x20 ? seen 0,5


### PR DESCRIPTION
All of these are of type "string", so no conversion is needed.

Reference:
https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-oshared/3ef02e83-afef-4b6c-9585-c109edd24e07