### PR TITLE
MKV Keywords is a comma separated list

### DIFF
--- a/lib/Image/ExifTool/Matroska.pm
+++ b/lib/Image/ExifTool/Matroska.pm
@@ -894,7 +894,7 @@ sub HandleStruct($$;$$$$)
         $code = $lang ? "${lang}-${ctry}" : "eng-${ctry}" if $ctry; # ('eng' is default lang)
 
         if ($$tagInfo{List}) {
-            my @values = split ',+\\s*', $val;
+            my @values = split ',\\s?', $val;
             $et->FoundTag($tagInfo, $_) foreach @values;
         } elsif ($code) {
             $tagInfo = Image::ExifTool::GetLangInfo($tagInfo, $code);

--- a/lib/Image/ExifTool/Matroska.pm
+++ b/lib/Image/ExifTool/Matroska.pm
@@ -788,7 +788,10 @@ my %uidInfo = (
     CONTENT_TYPE => 'ContentType',
     SUBJECT     => 'Subject',
     DESCRIPTION => 'Description',
-    KEYWORDS    => 'Keywords',
+    KEYWORDS    => {
+        Name => 'Keywords',
+        List => 1,
+    },
     SUMMARY     => 'Summary',
     SYNOPSIS    => 'Synopsis',
     INITIAL_KEY => 'InitialKey',
@@ -889,7 +892,11 @@ sub HandleStruct($$;$$$$)
         # (Note: not currently handling TagDefault attribute)
         my $code = $lang;
         $code = $lang ? "${lang}-${ctry}" : "eng-${ctry}" if $ctry; # ('eng' is default lang)
-        if ($code) {
+
+        if ($$tagInfo{List}) {
+            my @values = split ',+\\s*', $val;
+            $et->FoundTag($tagInfo, $_) foreach @values;
+        } elsif ($code) {
             $tagInfo = Image::ExifTool::GetLangInfo($tagInfo, $code);
             $et->HandleTag($tagTbl, $$tagInfo{TagID}, $val);
         } else {


### PR DESCRIPTION
According to https://www.matroska.org/technical/tagging.html, Keywords should be treated as a comma separated list. I've added support for tags being a comma separated list in MKV and set keywords to use this.

First time ever working in Perl so I hope I figured it out correctly 😅