### PR TITLE
Add support for Windows paths longer than 260 characters on supported Windows versions

### DIFF
--- a/README
+++ b/README
@@ -158,6 +158,7 @@ for calculating digest values and providing other features listed below:
   Unicode::LineBreak   (for column alignment of alternate-language output)
   Win32::API           (for proper handling of Windows file times)
   Win32::FindFile      (for Windows Unicode directory support, app only)
+  Win32::LongPath      (for reading files with paths longer than 260 characters in Windows)
   Win32API::File       (for Windows Unicode file names and file times)
   Compress::Raw::Lzma  (for reading encoded 7z files)
   IO::Compress::RawDeflate   (for writing FLIF images)

--- a/README
+++ b/README
@@ -158,7 +158,6 @@ for calculating digest values and providing other features listed below:
   Unicode::LineBreak   (for column alignment of alternate-language output)
   Win32::API           (for proper handling of Windows file times)
   Win32::FindFile      (for Windows Unicode directory support, app only)
-  Win32::LongPath      (for reading files with paths longer than 260 characters in Windows)
   Win32API::File       (for Windows Unicode file names and file times)
   Compress::Raw::Lzma  (for reading encoded 7z files)
   IO::Compress::RawDeflate   (for writing FLIF images)

--- a/exiftool
+++ b/exiftool
@@ -303,7 +303,6 @@ my @recommends = qw(
     IO::Uncompress::Brotli
     Win32::API
     Win32::FindFile
-    Win32::LongPath
     Win32API::File
 );
 my %altRecommends = (
@@ -1029,7 +1028,7 @@ for (;;) {
         }
         $trkfile or Error("Expecting file name for -geotag option\n"), $badCmd=1, next;
         # allow wildcards in filename
-        if ($trkfile =~ /[*?]/) {
+        if (Image::ExifTool::ContainsWildcards $trkfile) {
             # CORE::glob() splits on white space, so use File::Glob if possible
             my @trks;
             if ($^O eq 'MSWin32' and eval { require Win32::FindFile }) {
@@ -1415,7 +1414,7 @@ for (;;) {
         push @nextPass, $_;
         next;
     }
-    if ($doGlob and /[*?]/) {
+    if ($doGlob and Image::ExifTool::ContainsWildcards $_) {
         if ($^O eq 'MSWin32' and eval { require Win32::FindFile }) {
             push @files, FindFileWindows($mt, $_);
         } else {
@@ -3894,14 +3893,20 @@ sub ScanDir($$;$)
     return if $ignore{$dir};
     # use Win32::FindFile on Windows if available
     # (ReadDir will croak if there is a wildcard, so check for this)
-    if ($^O eq 'MSWin32' and $dir !~ /[*?]/) {
+    if ($^O eq 'MSWin32' and not Image::ExifTool::ContainsWildcards $dir) {
         undef $evalWarning;
         local $SIG{'__WARN__'} = sub { $evalWarning = $_[0] };;
-        if (CheckUTF8($dir, $enc) >= 0) {
+        if (1 or CheckUTF8($dir, $enc) >= 0) { # CheckUTF8 here doesn't seem to be necessary
             if (eval { require Win32::FindFile }) {
                 eval {
+                    # Unfortunately, Win32::FindFile::ReadDir doesn't handle long paths correctly, and will always return an empty list.
+                    # We should consider moving away from this, as its last update was in 2014.
                     @fileList = Win32::FindFile::ReadDir($dir);
                     $_ = $_->cFileName foreach @fileList;
+
+                    if (eval { require Encode }) {
+                        $_ = Encode::decode('utf8', $_) foreach @fileList;
+                    }
                 };
                 $@ and $evalWarning = $@;
                 if ($evalWarning) {
@@ -4020,7 +4025,7 @@ sub FindFileWindows($$)
     $wildfile = $et->Decode($wildfile, $enc, undef, 'UTF8') if $enc and $enc ne 'UTF8';
     $wildfile =~ tr/\\/\//; # use forward slashes
     my ($dir, $wildname) = ($wildfile =~ m{(.*[:/])(.*)}) ? ($1, $2) : ('', $wildfile);
-    if ($dir =~ /[*?]/) {
+    if (Image::ExifTool::ContainsWildcards $dir) {
         Warn "Wildcards don't work in the directory specification\n";
         return ();
     }

--- a/exiftool
+++ b/exiftool
@@ -303,6 +303,7 @@ my @recommends = qw(
     IO::Uncompress::Brotli
     Win32::API
     Win32::FindFile
+    Win32::LongPath
     Win32API::File
 );
 my %altRecommends = (

--- a/exiftool
+++ b/exiftool
@@ -3896,17 +3896,11 @@ sub ScanDir($$;$)
     if ($^O eq 'MSWin32' and not Image::ExifTool::ContainsWildcards $dir) {
         undef $evalWarning;
         local $SIG{'__WARN__'} = sub { $evalWarning = $_[0] };;
-        if (1 or CheckUTF8($dir, $enc) >= 0) { # CheckUTF8 here doesn't seem to be necessary
+        if (CheckUTF8($dir, $enc) >= 0) {
             if (eval { require Win32::FindFile }) {
                 eval {
-                    # Unfortunately, Win32::FindFile::ReadDir doesn't handle long paths correctly, and will always return an empty list.
-                    # We should consider moving away from this, as its last update was in 2014.
                     @fileList = Win32::FindFile::ReadDir($dir);
                     $_ = $_->cFileName foreach @fileList;
-
-                    if (eval { require Encode }) {
-                        $_ = Encode::decode('utf8', $_) foreach @fileList;
-                    }
                 };
                 $@ and $evalWarning = $@;
                 if ($evalWarning) {

--- a/lib/Image/ExifTool.pm
+++ b/lib/Image/ExifTool.pm
@@ -4616,13 +4616,7 @@ sub EncodeFileName($$;$)
                 local $SIG{'__WARN__'} = \&SetWarning;
                 if (eval { require Win32API::File }) {
                     # recode as UTF-16LE and add null terminator
-                    if (eval { require Encode; Encode::encode('utf16-le', $file) }) {
-                        # use Encode module as it is more reliable when detecting the source encoding
-                        $_[1] = Encode::encode('utf16-le', $file) . "\0\0";
-                    } else {
-                        # fall back to using our own UTF-16LE encoder
-                        $_[1] = $self->Decode($file, $enc, undef, 'UTF16', 'II') . "\0\0";
-                    }
+                    $_[1] = $self->Decode($file, $enc, undef, 'UTF16', 'II') . "\0\0";
                     return 1;
                 }
                 $self->WarnOnce('Install Win32API::File for Windows Unicode file support');

--- a/windows_exiftool
+++ b/windows_exiftool
@@ -295,6 +295,7 @@ my @recommends = qw(
     IO::Uncompress::Brotli
     Win32::API
     Win32::FindFile
+    Win32::LongPath
     Win32API::File
 );
 my %altRecommends = (

--- a/windows_exiftool
+++ b/windows_exiftool
@@ -295,7 +295,6 @@ my @recommends = qw(
     IO::Uncompress::Brotli
     Win32::API
     Win32::FindFile
-    Win32::LongPath
     Win32API::File
 );
 my %altRecommends = (
@@ -1042,7 +1041,7 @@ for (;;) {
         }
         $trkfile or Error("Expecting file name for -geotag option\n"), $badCmd=1, next;
         # allow wildcards in filename
-        if ($trkfile =~ /[*?]/) {
+        if (Image::ExifTool::ContainsWildcards $trkfile) {
             # CORE::glob() splits on white space, so use File::Glob if possible
             my @trks;
             if ($^O eq 'MSWin32' and eval { require Win32::FindFile }) {
@@ -1428,7 +1427,7 @@ for (;;) {
         push @nextPass, $_;
         next;
     }
-    if ($doGlob and /[*?]/) {
+    if ($doGlob and Image::ExifTool::ContainsWildcards $_) {
         if ($^O eq 'MSWin32' and eval { require Win32::FindFile }) {
             push @files, FindFileWindows($mt, $_);
         } else {
@@ -3891,14 +3890,20 @@ sub ScanDir($$;$)
     return if $ignore{$dir};
     # use Win32::FindFile on Windows if available
     # (ReadDir will croak if there is a wildcard, so check for this)
-    if ($^O eq 'MSWin32' and $dir !~ /[*?]/) {
+    if ($^O eq 'MSWin32' and not Image::ExifTool::ContainsWildcards $dir) {
         undef $evalWarning;
         local $SIG{'__WARN__'} = sub { $evalWarning = $_[0] };;
-        if (CheckUTF8($dir, $enc) >= 0) {
+        if (1 or CheckUTF8($dir, $enc) >= 0) { # CheckUTF8 here doesn't seem to be necessary
             if (eval { require Win32::FindFile }) {
                 eval {
+                    # Unfortunately, Win32::FindFile::ReadDir doesn't handle long paths correctly, and will always return an empty list.
+                    # We should consider moving away from this, as its last update was in 2014.
                     @fileList = Win32::FindFile::ReadDir($dir);
                     $_ = $_->cFileName foreach @fileList;
+
+                    if (eval { require Encode }) {
+                        $_ = Encode::decode('utf8', $_) foreach @fileList;
+                    }
                 };
                 $@ and $evalWarning = $@;
                 if ($evalWarning) {
@@ -4017,7 +4022,7 @@ sub FindFileWindows($$)
     $wildfile = $et->Decode($wildfile, $enc, undef, 'UTF8') if $enc and $enc ne 'UTF8';
     $wildfile =~ tr/\\/\//; # use forward slashes
     my ($dir, $wildname) = ($wildfile =~ m{(.*[:/])(.*)}) ? ($1, $2) : ('', $wildfile);
-    if ($dir =~ /[*?]/) {
+    if (Image::ExifTool::ContainsWildcards $dir) {
         Warn "Wildcards don't work in the directory specification\n";
         return ();
     }

--- a/windows_exiftool
+++ b/windows_exiftool
@@ -3893,17 +3893,11 @@ sub ScanDir($$;$)
     if ($^O eq 'MSWin32' and not Image::ExifTool::ContainsWildcards $dir) {
         undef $evalWarning;
         local $SIG{'__WARN__'} = sub { $evalWarning = $_[0] };;
-        if (1 or CheckUTF8($dir, $enc) >= 0) { # CheckUTF8 here doesn't seem to be necessary
+        if (CheckUTF8($dir, $enc) >= 0) {
             if (eval { require Win32::FindFile }) {
                 eval {
-                    # Unfortunately, Win32::FindFile::ReadDir doesn't handle long paths correctly, and will always return an empty list.
-                    # We should consider moving away from this, as its last update was in 2014.
                     @fileList = Win32::FindFile::ReadDir($dir);
                     $_ = $_->cFileName foreach @fileList;
-
-                    if (eval { require Encode }) {
-                        $_ = Encode::decode('utf8', $_) foreach @fileList;
-                    }
                 };
                 $@ and $evalWarning = $@;
                 if ($evalWarning) {


### PR DESCRIPTION
- This commits tries to use `openL` and `testL` from `Win32::LongPath` as a drop-in replacement for Perl's native `open` and file test `-t` if possible.
- All tests have passed on my Windows 11 machine with long path enabled. We could probably add some tests for this, which should be ignore if any of this isn't true:
  - Is not running on Windows
  - Windows version doesn't [support long file path](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation)
  - Registry value `HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem LongPathsEnabled` is not set to `DWORD 1`

This would fix the issues mentioned in https://exiftool.org/forum/index.php?topic=15095.0 and related threads.