### PR TITLE
Add support for multiple protobuf variants of DJI

### DIFF
--- a/lib/Image/ExifTool/DJI.pm
+++ b/lib/Image/ExifTool/DJI.pm
@@ -532,6 +532,7 @@ my %convFloat2 = (
         SubDirectory => { TagTable => 'Image::ExifTool::DJI::GPSInfo' },
     },
     'dvtm_dji_neo_3-4-4-2' => { Name => 'AbsoluteAltitude', Format => 'int64s', ValueConv => '$val / 1000' }, # (NC)
+#
 # Air 3
 #
     'dvtm_Air3_1-1-5' => { Name => 'SerialNumber', Notes => 'Air 3' },


### PR DESCRIPTION
They all seem to work well except for dvtm_wa345e.proto (Matrice 4E), which is printing the data already in a different format, so I assume a different part of the program is parsing it