### PR TITLE
add .pre-commit-hooks.yaml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- language: script
+  id: exiftool
+  name: exiftool
+  entry: ./exiftool
+  types:
+    - image


### PR DESCRIPTION
This allows you to use [prek](https://github.com/j178/prek) or [pre-commit](https://pre-commit.com/) to fetch, install this repo, and invoke exiftool directly in a sandboxed environment without needing to manually install it on your system.

For example, to set up a pre-commit hook to automatically strip away gps data from images before committing them to a repo, a user could just add something like this to their `.pre-commit-config.yaml`:

```yaml
  - repo: https://github.com/r-downing/exiftool
    rev: testtag  #or something like "13.34"
    hooks:
      - id: exiftool
        # remove all gps data from images before comitting
        args: [-overwrite_original_in_place, -gps:all=]
```