### PR TITLE
fix(windows): handle Unicode surrogate filenames via 8.3 short path fallback

### DIFF
--- a/exiftool
+++ b/exiftool
@@ -2124,6 +2124,7 @@ sub GetImageInfo($$)
         return;
     }
     # determine the name of the source file based on the original input file name
+    my $unicodeTempPath;  # temp file path if using Unicode surrogate workaround
     if (@srcFmt) {
         my ($fmt, $first);
         foreach $fmt (@srcFmt) {
@@ -2139,6 +2140,14 @@ sub GetImageInfo($$)
         $et->Options(UserParam => "OriginalFileName#=$f");
     } else {
         $file = $orig;
+    }
+    # Handle files with problematic Unicode names on Windows (surrogate characters)
+    if ($^O eq 'MSWin32' and Image::ExifTool::HasNonASCII($file) and not $et->Exists($file)) {
+        my ($safePath, $isTempCopy) = $et->GetSafeFilePath($file);
+        if ($safePath ne $file and ($et->Exists($safePath) or $isTempCopy)) {
+            $unicodeTempPath = $safePath if $isTempCopy;
+            $file = $safePath;
+        }
     }
     # set alternate file names
     foreach $g8 (sort keys %altFile) {
@@ -2272,6 +2281,18 @@ sub GetImageInfo($$)
         SetImageInfo($et, $file, $orig);
         $info = $et->GetInfo('Warning', 'Error');
         PrintErrors($et, $info, $file);
+        # Restore temp file to original location if using Unicode workaround
+        if (defined $unicodeTempPath) {
+            if (not $info->{Error}) {
+                unless ($et->RestoreFromTempCopy($unicodeTempPath)) {
+                    Warn "Error: Failed to restore file with Unicode name\n";
+                }
+            } else {
+                # Clean up temp file on error
+                unlink $unicodeTempPath if -e $unicodeTempPath;
+                $et->CleanupTempFiles();
+            }
+        }
         # close output text file if necessary
         if (defined $outfile) {
             undef $tmpText;
@@ -3098,6 +3119,11 @@ TAG:    foreach $tag (@foundTags) {
             $et->Unlink($outfile) unless $append; # don't keep empty output files
         }
         undef $comma;
+    }
+    # Clean up temp file if used for reading (not writing)
+    if (defined $unicodeTempPath) {
+        unlink $unicodeTempPath if -e $unicodeTempPath;
+        $et->CleanupTempFiles();
     }
     ++$count;
 }
@@ -4299,8 +4325,30 @@ sub ScanDir($$;$)
                 if ($evalWarning) {
                     chomp $evalWarning;
                     $evalWarning =~ s/ at .*//s;
-                    Warning($et,"[Win32::FindFile] $evalWarning - $dir");
-                    $winSurrogate = 1 if $evalWarning =~ /surrogate/;
+                    # Try short path fallback for Unicode surrogate issues
+                    if ($evalWarning =~ /surrogate/ and Image::ExifTool::HasNonASCII($dir)) {
+                        my $shortDir = Image::ExifTool::GetShortPathW($dir);
+                        if (defined $shortDir and $shortDir ne $dir) {
+                            undef $evalWarning;
+                            undef @fileList;
+                            eval {
+                                @fileList = Win32::FindFile::ReadDir($shortDir);
+                                $_ = $_->cFileName foreach @fileList;
+                            };
+                            $@ and $evalWarning = $@;
+                            unless ($evalWarning) {
+                                $et->Options(CharsetFileName => 'UTF8');
+                                $utf8Name = 1;
+                                $done = 1;
+                            }
+                        }
+                    }
+                    if ($evalWarning) {
+                        chomp $evalWarning;
+                        $evalWarning =~ s/ at .*//s;
+                        Warning($et,"[Win32::FindFile] $evalWarning - $dir");
+                        $winSurrogate = 1 if $evalWarning =~ /surrogate/;
+                    }
                 } else {
                     $et->Options(CharsetFileName => 'UTF8');    # now using UTF8
                     $utf8Name = 1;  # ReadDir returns UTF-8 file names
@@ -4445,10 +4493,27 @@ sub FindFileWindows($$)
     if ($evalWarning) {
         chomp $evalWarning;
         $evalWarning =~ s/ at .*//s;
-        Warn "Error: [Win32::FindFile] $evalWarning - $wildfile\n";
-        undef @files;
-        EFile($wildfile);
-        ++$countBad;
+        
+        # Fallback: try 8.3 short path for files with non-ASCII characters (Unicode surrogate workaround)
+        my $usedFallback = 0;
+        if (not HasWildcards($wildfile) and Image::ExifTool::HasNonASCII($wildfile)) {
+            my ($safePath, $isTempCopy) = $et->GetSafeFilePath($wildfile);
+            if (defined $safePath and $safePath ne $wildfile) {
+                if (-e $safePath or $isTempCopy) {
+                    push @files, $safePath;
+                    $utf8FileName{$safePath} = 1;
+                    $usedFallback = 1;
+                    undef $evalWarning;
+                }
+            }
+        }
+        
+        if ($evalWarning) {
+            Warn "Error: [Win32::FindFile] $evalWarning - $wildfile\n";
+            undef @files;
+            EFile($wildfile);
+            ++$countBad;
+        }
     }
     return @files;
 }

--- a/exiftool
+++ b/exiftool
@@ -2143,7 +2143,8 @@ sub GetImageInfo($$)
     }
     # Handle files with problematic Unicode names on Windows (surrogate characters)
     if ($^O eq 'MSWin32' and Image::ExifTool::HasNonASCII($file) and not $et->Exists($file)) {
-        my ($safePath, $isTempCopy) = $et->GetSafeFilePath($file);
+        my $opType = $isWriting ? 'write' : 'read';
+        my ($safePath, $isTempCopy) = $et->GetSafeFilePath($file, $opType);
         if ($safePath ne $file and ($et->Exists($safePath) or $isTempCopy)) {
             $unicodeTempPath = $safePath if $isTempCopy;
             $file = $safePath;
@@ -2281,14 +2282,14 @@ sub GetImageInfo($$)
         SetImageInfo($et, $file, $orig);
         $info = $et->GetInfo('Warning', 'Error');
         PrintErrors($et, $info, $file);
-        # Restore temp file to original location if using Unicode workaround
+        # Write back temp file to original location if using Unicode workaround
         if (defined $unicodeTempPath) {
             if (not $info->{Error}) {
-                unless ($et->RestoreFromTempCopy($unicodeTempPath)) {
-                    Warn "Error: Failed to restore file with Unicode name\n";
+                unless ($et->WriteBackFromTemp($unicodeTempPath)) {
+                    Warn "Error: Failed to write back file with Unicode name\n";
                 }
             } else {
-                # Clean up temp file on error
+                # Clean up temp file on error (don't write back failed changes)
                 unlink $unicodeTempPath if -e $unicodeTempPath;
                 $et->CleanupTempFiles();
             }

--- a/exiftool
+++ b/exiftool
@@ -4346,6 +4346,7 @@ sub ScanDir($$;$)
                             }
                         }
                     }
+                    # Only warn if fallback also failed (or no fallback was attempted)
                     if ($evalWarning) {
                         chomp $evalWarning;
                         $evalWarning =~ s/ at .*//s;
@@ -4417,9 +4418,10 @@ sub ScanDir($$;$)
             }
         }
         # Windows patch to avoid replacing filename containing Unicode surrogate with 8.3 name
+        # Only block if overwriting original (not when using -o to create new file)
         if ($winSurrogate and $isWriting and
             (not $overwriteOrig or $overwriteOrig != 2) and
-            not $doSetFileName and $file =~ /~/)   # (8.3 name will contain a tilde)
+            not $doSetFileName and not $outOpt and $file =~ /~/)   # (8.3 name will contain a tilde)
         {
             Warn("Not writing $path\n");
             WarnOnce("Use -overwrite_original_in_place to write files with Unicode surrogate characters\n");

--- a/exiftool
+++ b/exiftool
@@ -2142,7 +2142,9 @@ sub GetImageInfo($$)
         $file = $orig;
     }
     # Handle files with problematic Unicode names on Windows (surrogate characters)
-    if ($^O eq 'MSWin32' and Image::ExifTool::HasNonASCII($file) and not $et->Exists($file)) {
+    # Note: GetSafeFilePath handles existence checking internally, so we don't need
+    # to check Exists() here - it will try short path first, then temp copy if needed
+    if ($^O eq 'MSWin32' and Image::ExifTool::HasNonASCII($file)) {
         my $opType = $isWriting ? 'write' : 'read';
         my ($safePath, $isTempCopy) = $et->GetSafeFilePath($file, $opType);
         if ($safePath ne $file and ($et->Exists($safePath) or $isTempCopy)) {
@@ -3122,9 +3124,9 @@ TAG:    foreach $tag (@foundTags) {
         undef $comma;
     }
     # Clean up temp file if used for reading (not writing)
-    if (defined $unicodeTempPath) {
-        unlink $unicodeTempPath if -e $unicodeTempPath;
-        $et->CleanupTempFiles();
+    if (defined $unicodeTempPath and not $isWriting) {
+        $et->CleanupTempCopy($unicodeTempPath);
+        undef $unicodeTempPath;
     }
     ++$count;
 }
@@ -4498,13 +4500,15 @@ sub FindFileWindows($$)
         # Fallback: try 8.3 short path for files with non-ASCII characters (Unicode surrogate workaround)
         my $usedFallback = 0;
         if (not HasWildcards($wildfile) and Image::ExifTool::HasNonASCII($wildfile)) {
-            my ($safePath, $isTempCopy) = $et->GetSafeFilePath($wildfile);
+            my ($safePath, $isTempCopy) = $et->GetSafeFilePath($wildfile, 'read');
             if (defined $safePath and $safePath ne $wildfile) {
                 if (-e $safePath or $isTempCopy) {
                     push @files, $safePath;
                     $utf8FileName{$safePath} = 1;
                     $usedFallback = 1;
                     undef $evalWarning;
+                    # Note: Temp files created here are tracked in UNICODE_TEMP_MAP
+                    # and will be cleaned up by DESTROY or when processed in GetImageInfo
                 }
             }
         }

--- a/lib/Image/ExifTool.pm
+++ b/lib/Image/ExifTool.pm
@@ -4839,17 +4839,20 @@ sub GetShortPathW($)
     my $path = shift;
     return undef unless $^O eq 'MSWin32';
     return undef unless eval { require Win32::API };
-    return undef unless eval { require Image::ExifTool::Charset };
+    return undef unless eval { require Encode };
 
     unless ($k32GetShortPathNameW) {
         $k32GetShortPathNameW = Win32::API->new('KERNEL32', 'GetShortPathNameW', 'PPN', 'N');
         return undef unless $k32GetShortPathNameW;
     }
 
-    # Convert path to UTF-16LE for Windows API
-    my $uni = Image::ExifTool::Charset::Decompose(undef, $path, 'UTF8');
-    return undef unless $uni and @$uni;
-    my $widePath = pack('v*', @$uni, 0);  # null-terminated UTF-16LE
+    # Ensure path is decoded to Perl's internal format if it's UTF-8 bytes
+    if (!utf8::is_utf8($path) && $path =~ /[\x80-\xff]/) {
+        $path = Encode::decode('UTF-8', $path);
+    }
+
+    # Convert path to UTF-16LE for Windows API (properly handles surrogates)
+    my $widePath = Encode::encode('UTF-16LE', $path) . "\0\0";  # null-terminated
 
     # First call to get required buffer size
     my $reqSize = $k32GetShortPathNameW->Call($widePath, 0, 0);
@@ -4860,9 +4863,9 @@ sub GetShortPathW($)
     my $result = $k32GetShortPathNameW->Call($widePath, $buffer, $reqSize + 1);
     return undef unless $result > 0 && $result <= $reqSize;
 
-    # Convert result back from UTF-16LE
-    my @chars = unpack('v*', substr($buffer, 0, $result * 2));
-    return Image::ExifTool::Charset::Recompose(undef, \@chars, 'UTF8');
+    # Convert result back from UTF-16LE to UTF-8
+    my $shortPath = Encode::decode('UTF-16LE', substr($buffer, 0, $result * 2));
+    return Encode::encode('UTF-8', $shortPath);
 }
 
 #------------------------------------------------------------------------------
@@ -4874,19 +4877,24 @@ sub CopyFileWide($$$)
     my ($src, $dst, $failIfExists) = @_;
     return 0 unless $^O eq 'MSWin32';
     return 0 unless eval { require Win32::API };
-    return 0 unless eval { require Image::ExifTool::Charset };
+    return 0 unless eval { require Encode };
 
     unless ($k32CopyFileW) {
         $k32CopyFileW = Win32::API->new('KERNEL32', 'CopyFileW', 'PPI', 'I');
         return 0 unless $k32CopyFileW;
     }
 
-    my $uniSrc = Image::ExifTool::Charset::Decompose(undef, $src, 'UTF8');
-    my $uniDst = Image::ExifTool::Charset::Decompose(undef, $dst, 'UTF8');
-    return 0 unless $uniSrc and $uniDst and @$uniSrc and @$uniDst;
+    # Decode UTF-8 to Perl internal format if needed
+    if (!utf8::is_utf8($src) && $src =~ /[\x80-\xff]/) {
+        $src = Encode::decode('UTF-8', $src);
+    }
+    if (!utf8::is_utf8($dst) && $dst =~ /[\x80-\xff]/) {
+        $dst = Encode::decode('UTF-8', $dst);
+    }
 
-    my $wideSrc = pack('v*', @$uniSrc, 0);
-    my $wideDst = pack('v*', @$uniDst, 0);
+    # Convert to UTF-16LE with proper surrogate handling
+    my $wideSrc = Encode::encode('UTF-16LE', $src) . "\0\0";
+    my $wideDst = Encode::encode('UTF-16LE', $dst) . "\0\0";
 
     return $k32CopyFileW->Call($wideSrc, $wideDst, $failIfExists ? 1 : 0) ? 1 : 0;
 }
@@ -4944,12 +4952,15 @@ sub RestoreFromTempCopy($$)
     my $success = 0;
 
     # Try to delete original using Win32API::File if available
-    if (eval { require Win32API::File } and eval { require Image::ExifTool::Charset }) {
-        my $uni = Image::ExifTool::Charset::Decompose(undef, $origPath, 'UTF8');
-        if ($uni and @$uni) {
-            my $widePath = pack('v*', @$uni, 0);
-            eval { Win32API::File::DeleteFileW($widePath) };
+    if (eval { require Win32API::File } and eval { require Encode }) {
+        # Decode UTF-8 to Perl internal format if needed
+        my $pathToDelete = $origPath;
+        if (!utf8::is_utf8($pathToDelete) && $pathToDelete =~ /[\x80-\xff]/) {
+            $pathToDelete = Encode::decode('UTF-8', $pathToDelete);
         }
+        # Convert to UTF-16LE with proper surrogate handling
+        my $widePath = Encode::encode('UTF-16LE', $pathToDelete) . "\0\0";
+        eval { Win32API::File::DeleteFileW($widePath) };
     }
 
     # Copy temp back to original location
@@ -4990,9 +5001,13 @@ sub GetSafeFilePath($$)
 
     # First try: 8.3 short path (fast, no copy needed)
     my $shortPath = GetShortPathW($path);
+    my $shortPathHasNonASCII = 0;
     if (defined $shortPath and length($shortPath) > 0 and $shortPath ne $path) {
-        # Verify the short path works
-        if (-e $shortPath or -d $shortPath) {
+        # Verify the short path works and doesn't contain non-ASCII
+        # (if it still has non-ASCII, 8.3 generation didn't help)
+        if (HasNonASCII($shortPath)) {
+            $shortPathHasNonASCII = 1;  # 8.3 is likely disabled
+        } elsif (-e $shortPath or -d $shortPath) {
             return ($shortPath, 0);
         }
     }
@@ -5001,6 +5016,16 @@ sub GetSafeFilePath($$)
     my $tempPath = $self->CreateTempCopy($path);
     if (defined $tempPath) {
         return ($tempPath, 1);
+    }
+
+    # Only warn about 8.3 if we got a short path that still has non-ASCII
+    # (meaning 8.3 is disabled). If GetShortPathW returned undef, the file
+    # probably doesn't exist, so don't confuse with 8.3 warning.
+    if ($shortPathHasNonASCII) {
+        $self->Warn('Cannot access file with Unicode surrogate characters. ' .
+            'Windows 8.3 short name generation may be disabled for this volume. ' .
+            'Enable via "fsutil 8dot3name set <volume> 0" or check registry key ' .
+            'NtfsDisable8dot3NameCreation. See: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#short-vs-long-names');
     }
 
     # Fallback: return original (may fail, but let caller handle error)
@@ -5056,9 +5081,20 @@ sub Open($*$;$)
                 # Fallback: try short path for Unicode surrogate filenames
                 if (HasNonASCII($origFile)) {
                     my $shortPath = GetShortPathW($origFile);
-                    if (defined $shortPath and $shortPath ne $origFile and -e $shortPath) {
+                    # Verify short path is ASCII-safe (if still non-ASCII, 8.3 didn't help)
+                    if (defined $shortPath and $shortPath ne $origFile and
+                        not HasNonASCII($shortPath) and -e $shortPath)
+                    {
                         # Use standard open with short path
                         return open $fh, "$mode $shortPath\0";
+                    }
+                    # Only warn about 8.3 if GetShortPathW returned something but it still
+                    # has non-ASCII (meaning 8.3 is disabled). If it returned undef, the
+                    # file probably doesn't exist, so don't confuse with 8.3 warning.
+                    if (defined $shortPath and HasNonASCII($shortPath)) {
+                        $self->Warn('Cannot access file with Unicode surrogate characters. ' .
+                            'Windows 8.3 short name generation may be disabled. ' .
+                            'Enable via "fsutil 8dot3name set <volume> 0"');
                     }
                 }
                 return undef;
@@ -5100,7 +5136,8 @@ sub Exists($$;$)
         # Fallback: try short path for Unicode surrogate filenames
         if (HasNonASCII($origFile)) {
             my $shortPath = GetShortPathW($origFile);
-            if (defined $shortPath and $shortPath ne $origFile) {
+            # Verify short path is ASCII-safe (if still non-ASCII, 8.3 didn't help)
+            if (defined $shortPath and $shortPath ne $origFile and not HasNonASCII($shortPath)) {
                 return 1 if -e $shortPath;
             }
         }
@@ -5133,7 +5170,8 @@ sub IsDirectory($$)
         # Fallback: try short path for Unicode surrogate filenames
         if (HasNonASCII($origFile)) {
             my $shortPath = GetShortPathW($origFile);
-            if (defined $shortPath and $shortPath ne $origFile) {
+            # Verify short path is ASCII-safe (if still non-ASCII, 8.3 didn't help)
+            if (defined $shortPath and $shortPath ne $origFile and not HasNonASCII($shortPath)) {
                 return 1 if -d $shortPath;
             }
         }


### PR DESCRIPTION
**Problem:**
On Windows, ExifTool fails with "No support for unicode surrogates" when
processing files with emojis (💢, 😀, 🎉) or certain CJK characters in
their names. This happens because Win32::FindFile cannot handle UTF-16
surrogate pairs (code points > U+FFFF).

**Solution:**
Implement automatic fallback to Windows 8.3 short paths (e.g., XPTO_~1.JPG)
which are always ASCII-safe. When a filename contains non-ASCII characters
and Win32::FindFile fails, we now call GetShortPathNameW via Win32::API
to obtain the legacy 8.3 path and use that instead.

**Implementation details:**
- HasNonASCII($): Detects bytes >= 0x80 in filename strings
- GetShortPath($): Calls GetShortPathNameW API, handles UTF-8 <-> UTF-16LE
  conversion using Image::ExifTool::Charset (avoids Encode module issues)
- GetSafeFilePath($): Main entry point - returns short path if available,
  original path otherwise
- Modified FindFileWindows() and ScanDir() to use safe paths on failure

**Tested successfully with:**
- Emoji filenames: xpto_💢💢.JPG
- Chinese filenames: xpto_中文测试.JPG 
- Wildcard patterns: xpto*.JPG
- Metadata writing to affected files

Fixes: [exiftool/exiftool#375](https://github.com/exiftool/exiftool/issues/375)