### PR TITLE
add RF 200-800mm F6.3-9 IS USM with extender in Canon 61182 RF lens list

### DIFF
--- a/lib/Image/ExifTool/Canon.pm
+++ b/lib/Image/ExifTool/Canon.pm
@@ -649,6 +649,9 @@ $VERSION = '5.06';
    '61182.66' => 'Canon RF 45mm F1.2 STM', #42
    '61182.67' => 'Canon RF 7-14mm F2.8-3.5 L FISHEYE STM', #42
    '61182.68' => 'Canon RF 14mm F1.4 L VCM', #42
+   '61182.69' => 'Canon RF 200-800mm F6.3-9 IS USM', #github414
+   '61182.70' => 'Canon RF 200-800mm F6.3-9 IS USM + RF1.4x', #github414
+   '61182.71' => 'Canon RF 200-800mm F6.3-9 IS USM + RF2x', #github414
     65535 => 'n/a',
 );
 


### PR DESCRIPTION
In order to fix https://github.com/exiftool/exiftool/issues/414, I edit the code and add the model to 61182 RF Lens list. I have tested it on ver 13.55 and ver 13.57 on Mac. It works fine. So I make a pull request and hope it can be merged into upstream. Please review it and merge it. Thanks. 