### PR TITLE
test: add ID3 WXXX regression coverage

### DIFF
--- a/t/MP3.t
+++ b/t/MP3.t
@@ -2,7 +2,7 @@
 # After "make install" it should work as "perl t/MP3.t".
 
 BEGIN {
-    $| = 1; print "1..2\n"; $Image::ExifTool::configFile = '';
+    $| = 1; print "1..3\n"; $Image::ExifTool::configFile = '';
     require './t/TestLib.pm'; t::TestLib->import();
 }
 END {print "not ok 1\n" unless $loaded;}
@@ -23,6 +23,17 @@ my $testnum = 1;
     my $exifTool = Image::ExifTool->new;
     my $info = $exifTool->ImageInfo('t/images/MP3.mp3');
     notOK() unless check($exifTool, $info, $testname, $testnum);
+    print "ok $testnum\n";
+}
+
+# test 3: Decode ID3 WXXX frame values from an in-memory sample
+{
+    ++$testnum;
+    my $frame = "WXXX" . pack('Nn', 25, 0) . "\0home\0https://example.com";
+    my $data = "ID3\x03\x00\x00" . pack('C4', 0, 0, 0, length($frame)) . $frame;
+    my $exifTool = Image::ExifTool->new;
+    my $info = $exifTool->ImageInfo(\$data);
+    notOK() unless $$info{Home_URL} eq 'https://example.com';
     print "ok $testnum\n";
 }
 


### PR DESCRIPTION

**Repo:** exiftool/exiftool (⭐ 3000)
**Type:** test
**Files changed:** 1
**Lines:** +12/-1

## What
Adds a focused regression test to [`t/MP3.t`] that builds a minimal in-memory ID3v2.3 payload containing a `WXXX` frame and verifies ExifTool extracts the expected dynamic `Home_URL` tag value. The existing fixture-based MP3 test remains unchanged; this just extends coverage with a synthetic edge case that does not require another binary test asset.

## Why
`lib/Image/ExifTool/ID3.pm` contains dedicated parsing logic for `WXXX`/`UserDefinedURL` frames, but the MP3 test file did not exercise it at all. This patch closes that gap with a cheap regression test, making future changes to ID3 parsing less likely to silently break user-defined URL extraction.

## Testing
Ran `perl -Ilib t/MP3.t` locally. Result: `1..3`, `ok 1`, `ok 2`, `ok 3`.

## Risk
Low + test-only change with no production code impact.
