### PR TITLE
Add Lens IDs for Sigma 150+TC, 100-400/+TC, Tamron 85

### DIFF
--- a/lib/Image/ExifTool/Canon.pm
+++ b/lib/Image/ExifTool/Canon.pm
@@ -421,6 +421,7 @@ $VERSION = '5.06';
     213.2 => 'Tamron 16-300mm f/3.5-6.3 Di II VC PZD Macro (B016)', #PH
     213.3 => 'Tamron SP 35mm f/1.8 Di VC USD (F012)', #PH
     213.4 => 'Tamron SP 45mm f/1.8 Di VC USD (F013)', #PH
+    213.5 => 'Tamron SP 85mm f/1.8 Di VC USD (F012)',
     214 => 'Canon EF-S 18-55mm f/3.5-5.6 USM', #PH/34
     215 => 'Canon EF 55-200mm f/4.5-5.6 II USM',
     217 => 'Tamron AF 18-270mm f/3.5-6.3 Di II VC PZD', #47
@@ -493,6 +494,8 @@ $VERSION = '5.06';
    '368.13' => 'Sigma 24-105mm f/4 DG OS HSM | A', #forum3833
    '368.14' => 'Sigma 18-300mm f/3.5-6.3 DC Macro OS HSM | C', #forum15280 (014)
    '368.15' => 'Sigma 24mm F1.4 DG HSM | A', #50 (015)
+   '368.16' => 'Sigma 100-400mm f/5-6.3 DG OS HSM | C',
+   '368.17' => 'Sigma 100-400mm f/5-6.3 DG OS HSM | C + 1.4x',
     # Note: LensType 488 (0x1e8) is reported as 232 (0xe8) in 7D CameraSettings
     488 => 'Canon EF-S 15-85mm f/3.5-5.6 IS USM', #PH
     489 => 'Canon EF 70-300mm f/4-5.6L IS USM', #Gerald Kapounek

--- a/lib/Image/ExifTool/Nikon.pm
+++ b/lib/Image/ExifTool/Nikon.pm
@@ -388,6 +388,7 @@ sub GetAFPointGrid($$;$);
     'BE 54 6A 6A 0C 0C 4B 46' => 'Sigma 105mm F1.4 DG HSM | A', #30
     '48 48 76 76 24 24 4B 06' => 'Sigma APO Macro 150mm F2.8 EX DG HSM',
     'F5 48 76 76 24 24 4B 06' => 'Sigma APO Macro 150mm F2.8 EX DG HSM', #24
+    'F5 48 76 76 24 24 F1 06' => 'Sigma APO Macro 150mm F2.8 EX DG HSM + 1.4x TC',
     '99 48 76 76 24 24 4B 0E' => 'Sigma APO Macro 150mm F2.8 EX DG OS HSM', #(Christian Hesse)
     '48 4C 7C 7C 2C 2C 4B 02' => 'Sigma APO Macro 180mm F3.5 EX DG HSM',
     '48 4C 7D 7D 2C 2C 4B 02' => 'Sigma APO Macro 180mm F3.5 EX DG HSM',


### PR DESCRIPTION
This adds Lens IDs for:
* Tamron SP 85mm f/1.8 Di VC USD
* Sigma 100-400mm f/5-6.3 DG OS HSM | C (+1.4x teleconverter)
* Sigma 150mm F2.8 EX APO Macro DG HSM with 1.4x teleconverter

I wasn't entirely sure of the format for the Nikon Teleconverters, so I copied the Canon style. The canon ones have sample images uploaded to https://github.com/lensfun/lensfun/issues/2773