### PR TITLE
Add NewUUID tag to generate a version 4 (random) UUID as per RFC 9562.

### DIFF
--- a/lib/Image/ExifTool.pm
+++ b/lib/Image/ExifTool.pm
@@ -121,6 +121,7 @@ sub CopyFileAttrs($$$);
 sub TimeNow(;$$);
 sub InverseDateTime($$;$$);
 sub NewGUID();
+sub NewUUID();
 sub MakeTiffHeader($$$$;$$);
 
 # other subroutine definitions
@@ -1919,6 +1920,16 @@ my %systemTagsNotes = (
         },
         PrintConv => '$val =~ s/(.{8})(.{4})(.{4})(.{4})/$1-$2-$3-$4-/; $val',
     },
+    NewUUID => {
+        Groups => { 0 => 'ExifTool', 1 => 'ExifTool', 2 => 'Other' },
+        Notes => q{
+            generates a version 4 ("random"), variant 1 UUID as per RFC 9562, Section 5.4
+            with format xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx, where M=4 and N=8, 9, a, or b;
+            without dashes with the -n option.  Not generated unless specifically requested
+            or the API L<RequestAll|../ExifTool.html#RequestAll> option is set
+        },
+        PrintConv => '$val =~ s/(.{8})(.{4})(.{4})(.{4})/$1-$2-$3-$4-/; $val',
+    },
     ID3Size     => { Notes => 'size of the ID3 data block' },
     Geotag => {
         Writable => 1,
@@ -2769,6 +2780,7 @@ sub ExtractInfo($;@)
         $self->FoundTag('ExifToolVersion', "$VERSION$RELEASE");
         $self->FoundTag('Now', $self->TimeNow()) if $$req{now} or $reqAll;
         $self->FoundTag('NewGUID', NewGUID()) if $$req{newguid} or $reqAll;
+        $self->FoundTag('NewUUID', NewUUID()) if $$req{newuuid} or $reqAll;
         # generate sequence number if necessary
         $self->FoundTag('FileSequence', $$self{FILE_SEQUENCE}) if $$req{filesequence} or $reqAll;
 

--- a/lib/Image/ExifTool/TagLookup.pm
+++ b/lib/Image/ExifTool/TagLookup.pm
@@ -11431,6 +11431,7 @@ my %tagExists = (
 	'newcolortype' => 1,
 	'newguid' => 1,
 	'newlines' => 1,
+	'newuuid' => 1,
 	'nextbasemeta' => 1,
 	'nexttrackid' => 1,
 	'nifnonlinearity' => 1,

--- a/lib/Image/ExifTool/TagNames.pod
+++ b/lib/Image/ExifTool/TagNames.pod
@@ -47591,6 +47591,7 @@ FileName.
   MakerNoteByteOrder         File               no
   MaxVal                     File               no
   NewGUID                    ExifTool           no
+  NewUUID                    ExifTool           no
   Now                        ExifTool           no
   NumPlanes                  File               no
   OtherImage                 File               no

--- a/lib/Image/ExifTool/Writer.pl
+++ b/lib/Image/ExifTool/Writer.pl
@@ -4930,6 +4930,19 @@ sub NewGUID()
 }
 
 #------------------------------------------------------------------------------
+# Generate a version 4 ("random"), variant 1 UUID (RFC 9562, Section 5.4).
+# Inputs: <none>
+# Returns: UUID string
+sub NewUUID()
+{
+    my @rnd = map {int(rand(256))} 1 .. 16;
+    $rnd[6] = ($rnd[6] & 0x0f) | 0x40;
+    $rnd[8] = ($rnd[8] & 0x3f) | 0x80;
+    my $uuid = join '', map {chr} @rnd;
+    return join '', unpack('H8 H4 H4 H4 H12', $uuid);
+}
+
+#------------------------------------------------------------------------------
 # Make TIFF header for raw data
 # Inputs: 0) width, 1) height, 2) num colour components, 3) bits, 4) resolution
 #         5) color-map data for palette-color image (8 or 16 bit)

--- a/lib/Image/ExifTool/Writer.pl
+++ b/lib/Image/ExifTool/Writer.pl
@@ -4938,8 +4938,7 @@ sub NewUUID()
     my @rnd = map {int(rand(256))} 1 .. 16;
     $rnd[6] = ($rnd[6] & 0x0f) | 0x40;
     $rnd[8] = ($rnd[8] & 0x3f) | 0x80;
-    my $uuid = join '', map {chr} @rnd;
-    return join '', unpack('H8 H4 H4 H4 H12', $uuid);
+    return scalar unpack('H32', join '', map {chr} @rnd);
 }
 
 #------------------------------------------------------------------------------


### PR DESCRIPTION
The current NewGUID generates a GUID in a custom format. For various purposes, especially for filling up the Exif::ImageUniqueID tag, it would be useful to be able to generate an UUID in a well-known, defined form. Nowadays that is usually the UUID version 4 as defined in RFC 9562.

For this case, it seems overkill to use a CSPRNG, so `rand` is used. If needed, this can be improved by mixing in an LFSR or LCG, but this is improbable.