### PR TITLE
Fix HTML dump title injection

### DIFF
--- a/lib/Image/ExifTool/HtmlDump.pm
+++ b/lib/Image/ExifTool/HtmlDump.pm
@@ -469,7 +469,8 @@ sub Print($$;$$$$$)
     $raf->Seek($tell,0);
 
     # write output HTML file
-    Write($outfile, $htmlHeader1, $title);
+    my $htmlTitle = EscapeHTML($title);
+    Write($outfile, $htmlHeader1, $htmlTitle);
     if ($self->{Cols}->[0]) {
         Write($outfile, $htmlHeader2);
         my $mspan = \@{$$self{MSpanList}};
@@ -493,7 +494,7 @@ sub Print($$;$$$$$)
         $rtnVal = 1;
     } else {
         my $err = $$self{Error} || 'No EXIF or TIFF information found in image';
-        Write($outfile, "$title</title></head><body>\n$err\n");
+        Write($outfile, "$htmlTitle</title></head><body>\n$err\n");
         $rtnVal = 0;
     }
     Write($outfile, "</body></html>\n");
@@ -930,4 +931,3 @@ under the same terms as Perl itself.
 L<Image::ExifTool(3pm)|Image::ExifTool>
 
 =cut
-

--- a/t/HtmlDump.t
+++ b/t/HtmlDump.t
@@ -1,0 +1,29 @@
+# Before "make install", this script should be runnable with "make test".
+# After "make install" it should work as "perl t/HtmlDump.t".
+
+BEGIN {
+    $| = 1; print "1..2\n"; $Image::ExifTool::configFile = '';
+    require './t/TestLib.pm'; t::TestLib->import();
+}
+END {print "not ok 1\n" unless $loaded;}
+
+# test 1: Load the module(s)
+use Image::ExifTool::HtmlDump;
+use File::RandomAccess;
+$loaded = 1;
+print "ok 1\n";
+
+# test 2: Escape special characters in the HTML dump title
+{
+    my $data = 'test';
+    my $html = '';
+    my $raf = File::RandomAccess->new(\$data);
+    my $dump = Image::ExifTool::HtmlDump->new;
+    my $title = 'HTML Dump (</title><script>window.exiftoolPoc=1</script>)';
+    $dump->Print($raf, undef, 0, \$html, 1, $title);
+    notOK() unless ($html =~ /&lt;\/title&gt;&lt;script&gt;window\.exiftoolPoc=1&lt;\/script&gt;/ and
+                     $html !~ /<script>window\.exiftoolPoc=1<\/script>/);
+    print "ok 2\n";
+}
+
+done(); # end


### PR DESCRIPTION
Escape input-derived HTML dump titles before writing them to the report. This prevents attacker-controlled path components from breaking out of the title element when a generated report is opened. Adds a regression test.