### PR TITLE
Limit WOFF metadata decompression

### DIFF
--- a/lib/Image/ExifTool/Font.pm
+++ b/lib/Image/ExifTool/Font.pm
@@ -29,6 +29,9 @@ sub ProcessOTF($$);
 # OTF tags to process (skip all others)
 my %processTag = ( name => 1, C2PA => 1 );
 
+# maximum size of font data to read or uncompress (100 MB)
+my $maxFontDataSize = 100000000;
+
 # TrueType 'name' platform codes
 my %ttPlatform = (
     0 => 'Unicode',
@@ -669,22 +672,44 @@ sub ReadUIntBase128($)
 
 #------------------------------------------------------------------------------
 # Uncompress data
-# Inputs: 0) ExifTool ref, 1) data ref
+# Inputs: 0) ExifTool ref, 1) data ref, 2) maximum output size (optional)
 # Returns: true on success
-sub Uncompress($$)
+sub Uncompress($$;$)
 {
-    my ($et, $dataPt) = @_;
-    my $stat;
+    my ($et, $dataPt, $maxLen) = @_;
+    my ($data, $stat);
+    $maxLen = $maxFontDataSize unless defined $maxLen;
     unless (eval { require Compress::Zlib }) {
         $et->Warn('Install Compress::Zlib to read compressed metadata');
         return 0;
     }
     my $inflate = Compress::Zlib::inflateInit();
-    $inflate and ($$dataPt, $stat) = $inflate->inflate($$dataPt);
-    unless ($inflate and $stat == Compress::Zlib::Z_STREAM_END()) {
+    unless ($inflate) {
         $et->Warn('Error uncompressing metadata');
         return 0;
     }
+    while (length $$dataPt) {
+        my $input = substr($$dataPt, 0, 4096, '');
+        my ($out, $status) = $inflate->inflate($input);
+        unless ($status == Compress::Zlib::Z_OK() or
+                $status == Compress::Zlib::Z_STREAM_END())
+        {
+            $et->Warn('Error uncompressing metadata');
+            return 0;
+        }
+        if (length($out) > $maxLen - length($data)) {
+            $et->Warn('Uncompressed metadata is too large');
+            return 0;
+        }
+        $data .= $out;
+        $stat = $status;
+        last if $stat == Compress::Zlib::Z_STREAM_END();
+    }
+    unless ($stat and $stat == Compress::Zlib::Z_STREAM_END()) {
+        $et->Warn('Error uncompressing metadata');
+        return 0;
+    }
+    $$dataPt = $data;
     return 1;
 }
 
@@ -740,6 +765,8 @@ sub ProcessWOFF($$)
             my $pt = $i * 20;
             my ($tag, $pos, $compLen, $len) = unpack("x${pt}a4N3", $tbl);
             next unless $processTag{$tag} or $verbose;
+            $compLen <= $maxFontDataSize and $len <= $maxFontDataSize or
+                $et->Warn('Font table too large'), next;
             $raf->Seek($pos,0) and $raf->Read($buff,$compLen)==$compLen or $et->Warn('Bad font table entry'), return 1;
             my $dataPos;
             if ($compLen eq $len) {
@@ -783,6 +810,7 @@ sub ProcessWOFF($$)
             }
             $err and $et->Warn('Error reading collection directory'), return 1;
         }
+        $compSize <= $maxFontDataSize or $et->Warn('Font data too large'), return 1;
         $raf->Read($buff,$compSize) == $compSize or $et->Warn('Error reading font data'), return 1;
         return 1 unless Unbrotli($et, \$buff);
         # after all that exhausting and frankly unnecessary work (poor file design),
@@ -803,6 +831,7 @@ sub ProcessWOFF($$)
 # read compressed XML-format metadata (NC)
 #
     if ($metaLen) {
+        $metaLen <= $maxFontDataSize or $et->Warn('Font metadata too large'), return 1;
         unless ($raf->Seek($metaPos,0) and $raf->Read($buff,$metaLen)==$metaLen) {
             $et->Warn('Error reading metadata');
             return 1;
@@ -929,4 +958,3 @@ L<Image::ExifTool::TagNames/Font Tags>,
 L<Image::ExifTool(3pm)|Image::ExifTool>
 
 =cut
-

--- a/t/Font.t
+++ b/t/Font.t
@@ -2,7 +2,7 @@
 # After "make install" it should work as "perl t/Font.t".
 
 BEGIN {
-    $| = 1; print "1..7\n"; $Image::ExifTool::configFile = '';
+    $| = 1; print "1..10\n"; $Image::ExifTool::configFile = '';
     require './t/TestLib.pm'; t::TestLib->import();
 }
 END {print "not ok 1\n" unless $loaded;}
@@ -26,6 +26,42 @@ my $testnum = 1;
         notOK() unless check($exifTool, $info, $testname, $testnum);
         print "ok $testnum\n";
     }
+}
+
+# tests 8/10: Test bounded WOFF zlib decompression
+{
+    my $skip = '';
+    if (eval { require Compress::Zlib }) {
+        my $data = Compress::Zlib::compress('A' x 1024);
+        my $exifTool = Image::ExifTool->new;
+        ++$testnum;
+        notOK() unless Image::ExifTool::Font::Uncompress($exifTool, \$data, 2048) and
+                       $data eq 'A' x 1024;
+        print "ok $testnum\n";
+
+        $data = Compress::Zlib::compress('A' x 1024);
+        $exifTool = Image::ExifTool->new;
+        ++$testnum;
+        notOK() unless not Image::ExifTool::Font::Uncompress($exifTool, \$data, 100) and
+                       $exifTool->GetValue('Warning') eq 'Uncompressed metadata is too large';
+        print "ok $testnum\n";
+    } else {
+        $skip = ' # skip Requires Compress::Zlib';
+        ++$testnum;
+        print "ok $testnum$skip\n";
+        ++$testnum;
+        print "ok $testnum$skip\n";
+    }
+
+    my $max = 100000001;
+    my $head = pack('a4a4NnnNnnNNNNN', 'wOFF', "\0\1\0\0", 65, 1, 0,
+                    $max, 1, 0, 0, 0, 0, 0, 0);
+    my $dir = pack('a4NNNN', 'name', 64, 1, $max, 0);
+    my $info = ImageInfo(\($head . $dir . "\0"));
+    ++$testnum;
+    notOK() unless $$info{FileType} eq 'WOFF' and
+                   $$info{Warning} eq 'Font table too large';
+    print "ok $testnum\n";
 }
 
 done(); # end


### PR DESCRIPTION
Reject oversized WOFF font data and inflate zlib metadata in bounded chunks. This prevents compressed metadata from forcing unbounded memory allocation when ExifTool scans an untrusted font. Adds regression tests.