### PR TITLE
Fix silent wrong write when Orientation is set as an integer value

### DIFF
--- a/lib/Image/ExifTool/Writer.pl
+++ b/lib/Image/ExifTool/Writer.pl
@@ -3619,6 +3619,8 @@ sub ReverseLookup($$)
             $val = hex($val);   # convert hex value
         }
     } else {
+        # accept a raw value if it matches a hash key directly (eg. -Orientation=1)
+        return $val if exists $$conv{$val} and not $ignorePrintConv{$val};
         my $qval = $val;
         $qval =~ s/\s+$//;      # remove trailing whitespace
         $qval = quotemeta $qval;

--- a/t/Writer.t
+++ b/t/Writer.t
@@ -2,7 +2,7 @@
 # After "make install" it should work as "perl t/Writer.t".
 
 BEGIN {
-    $| = 1; print "1..61\n"; $Image::ExifTool::configFile = '';
+    $| = 1; print "1..62\n"; $Image::ExifTool::configFile = '';
     require './t/TestLib.pm'; t::TestLib->import();
 }
 END {print "not ok 1\n" unless $loaded;}
@@ -1138,6 +1138,30 @@ my $testOK;
         $skip = ' # POSIX::strptime or Time::Piece not installed';
     }
     print "ok $testnum$skip\n";
+}
+
+# test 62: Write Orientation as a plain integer (regression test for issue #459)
+#          (writing "-Orientation=1" used to silently persist 3 due to a
+#           substring match against the "Rotate 180" PrintConv value)
+{
+    ++$testnum;
+    my $exifTool = Image::ExifTool->new;
+    my $ok = 1;
+    my $v;
+    for $v (1..8) {
+        $exifTool->SetNewValue();
+        $exifTool->SetNewValue('IFD0:Orientation' => $v);
+        my $image;
+        writeInfo($exifTool, 't/images/Writer.jpg', \$image);
+        my $info = $exifTool->ImageInfo(\$image, 'IFD0:Orientation', { PrintConv => 0 });
+        my $wrote = $$info{'Orientation'} || '';
+        unless ($wrote eq "$v") {
+            warn "\n  Orientation=$v wrote '$wrote'\n";
+            $ok = 0;
+        }
+    }
+    notOK() unless $ok;
+    print "ok $testnum\n";
 }
 
 done(); # end


### PR DESCRIPTION
## Summary

Fixes #459.

Writing `-Orientation=N` (where `N` is a plain integer rather than a `PrintConv` string like `"Rotate 90 CW"`) used to silently persist a wrong value. With the upstream baseline below, every integer input was either rejected-as-no-op or written as the wrong value, with exit code 0 and **no warning**:

| write | read (before) |
|---|---|
| `-Orientation=1` | `Rotate 180` (raw value **3**) |
| `-Orientation=8` | `Rotate 180` (raw value **3**) |
| `-Orientation=2..7` | silently ignored |

String inputs (`-Orientation="Rotate 90 CW"`, `-Orientation="Horizontal (normal)"`, …) were always correct.

### Root cause

In `Writer.pl`, `ReverseLookup()` reverses a `PrintConv` hash by matching the incoming string against the hash **values** with progressively fuzzier patterns:

```perl
my @patterns = (
    "^$qval\$",         # exact match
    "^(?i)$qval\$",     # case-insensitive
    "^(?i)$qval",       # beginning of string
    "(?i)$qval",        # substring        <-- the problem
);
```

When the incoming value is a raw integer such as `"1"`, none of the first three patterns match any `PrintConv` value, so the final **substring** pattern kicks in. The pattern `(?i)1` matches `"Rotate 180"` (it contains the digit `1`), so the lookup silently returns key `3` and `3` is written to the file. The same substring trap pulls `-Orientation=8` to `3` via the `"180"` substring.

Because the lookup *succeeds*, no `Can't convert … (not in PrintConv)` warning is emitted — the file is corrupted silently, which is exactly what the reporter hit in production while normalizing orientation for AVIF export.

### Fix

If the incoming value matches a key of the `PrintConv` hash directly, treat it as a raw value and return it immediately, before attempting any fuzzy string matching:

```perl
# accept a raw value if it matches a hash key directly (eg. -Orientation=1)
return $val if exists $$conv{$val} and not $ignorePrintConv{$val};
```

This is placed at the top of the `else` branch in `ReverseLookup()`, ahead of the pattern matching. The `Unknown (…)` branch above is unaffected. PrintConv-string inputs (`"Rotate 90 CW"`, `"Horizontal"`, …) do not equal any hash key and fall through to the existing fuzzy logic, so existing behaviour for string inputs is unchanged.

### Verification

After the fix, the integer sweep from the issue produces the correct raw values, and string inputs still behave exactly as before:

```
write=1 read=Horizontal (normal)            write='Horizontal (normal)' read=Horizontal (normal)
write=2 read=Mirror horizontal              write='Rotate 90 CW'        read=Rotate 90 CW
write=3 read=Rotate 180                     write='Rotate 270 CW'       read=Rotate 270 CW
write=4 read=Mirror vertical                write='Rotate 180'          read=Rotate 180
write=5 read=Mirror horizontal and rotate 270 CW
write=6 read=Rotate 90 CW
write=7 read=Mirror horizontal and rotate 90 CW
write=8 read=Rotate 270 CW
```

Out-of-range integers (`-Orientation=99`) and nonsense strings still reject cleanly with the existing `Can't convert IFD0:Orientation (not in PrintConv)` warning and exit code 1.

### Regression test

Added `test 62` in `t/Writer.t`, which writes each integer value `1..8` to `Orientation` and asserts that the raw value stored in `IFD0:Orientation` (read with `PrintConv => 0`) equals the input. This test fails on the unpatched code (writes `3` for inputs `1` and `8`, and nothing for `2..7`) and passes after the one-line fix. The full `Writer.t`, `ExifTool.t`, `XMP.t`, `GPS.t`, `IPTC.t`, `Canon.t` and `Nikon.t` suites pass.

### Scope

The change is general to any `PrintConv` hash whose keys are written as plain strings, but in practice the substring trap is most damaging for small integer-valued enums (`Orientation`, `YCbCrPositioning`, etc.). The guard is conservative — it only short-circuits on an **exact** key match — so it cannot change behaviour for any value that does not already equal a raw key.

## Checklist

- [x] Reproduced the issue on 13.59
- [x] Fix verified against the full integer sweep (1..8) and string inputs from the report
- [x] Out-of-range / nonsense values still warn and exit non-zero
- [x] Added a regression test (`t/Writer.t` test 62)
- [x] Full Writer.t + representative suite (ExifTool/XMP/GPS/IPTC/Canon/Nikon) pass
