### PR TITLE
Write ExifIFD before SubIFD for Sony RAW images

### DIFF
--- a/lib/Image/ExifTool/WriteExif.pl
+++ b/lib/Image/ExifTool/WriteExif.pl
@@ -1746,6 +1746,7 @@ NoOverwrite:            next if $isNew > 0;
                                 Offset    => $offset,
                                 Where     => $where,
                                 ImageData => $subdirInfo{ImageData},
+                                TagID     => $newID,
                             };
                             ++$writeCount;  # count number of subdirs written
                         }
@@ -2121,6 +2122,25 @@ NoOverwrite:            next if $isNew > 0;
 #
 # add any subdirectories, adding fixup information
 #
+        # The Sony Imaging Edge applications refuse to open an ARW/ARQ image whose
+        # SubIFD comes before the ExifIFD in the file.  Sub-directories are generated
+        # in tag order, and SubIFD (0x014a) sorts before ExifIFD (0x8769), so every
+        # ExifTool edit inverted Sony's order.  Write the ExifIFD first for Sony RAW
+        # images to avoid this.  Nothing else needs to move: the TIFF specification
+        # doesn't specify an order, and each sub-directory carries its own pointer
+        # offset and fixups, so appending them in a different order is safe.
+        if (@subdirs > 1 and $$et{FileType} and $$et{FileType} =~ /^(ARW|ARQ|SR2)$/) {
+            my (@exifIFD, @otherIFD);
+            foreach (@subdirs) {
+                # (don't reorder a directory with image data blocks to transfer)
+                if ($$_{TagID} and $$_{TagID} == 0x8769 and not ref $$_{ImageData}) {
+                    push @exifIFD, $_;
+                } else {
+                    push @otherIFD, $_;
+                }
+            }
+            @subdirs = (@exifIFD, @otherIFD) if @exifIFD;
+        }
         if (@subdirs) {
             my $subdir;
             foreach $subdir (@subdirs) {


### PR DESCRIPTION
The Sony Imaging Edge applications refuse to open ARW/ARQ images edited by ExifTool -- a Known Problem documented since 2018-09-27.  The cause is the order in which the sub-IFDs are laid down in the file.

Sub-directories are generated during the entry loop, which runs in tag order, and are pushed onto @subdirs in that order, then appended to the output in the same order.  SubIFD is tag 0x014a and ExifIFD is tag 0x8769, so the SubIFD is always written first.  Sony's own writer does the opposite (eg. ExifIFD 4582, SubIFD 138462 on an ILCE-1), and Imaging Edge rejects the file when the order is inverted.  This happens for every write, which matches the reported symptom that any edit breaks the file.

Reorder @subdirs so the ExifIFD is appended first, for Sony RAW file types. Each entry already carries its own pointer Offset and Fixup (whose Start is adjusted from the current output length at append time), so nothing depends on the order of the array.  Entries carrying deferred ImageData blocks are left alone so the block transfer sequence is untouched.  TagID is added to the hash because it was not previously recorded.

Verified on four bodies (ILCE-1, ILCE-7M4, ILCE-7CR, ILCE-6400): the patched output has the correct order, reads back clean, and keeps the metadata and all embedded image blobs identical to what the current code produces.  Files written this way open in Imaging Edge; the same files written by the current code do not.  Non-Sony output is byte-identical and t/ passes 603/603.

I’m not a Perl expert, and the code was written with the help of an AI assistant, so please review it carefully. However, I did hands-on testing with several Sony camera bodies and can verify that it works.